### PR TITLE
40 onderbouw objecten opstellen uit rakdeelomschrijving voor rakdeel

### DIFF
--- a/src/tekstherkenning_ark/models/onderbouw.py
+++ b/src/tekstherkenning_ark/models/onderbouw.py
@@ -23,8 +23,7 @@ class Onderbouw(BaseModel):
     # Elke paalrij bevat de bijbehorende palen. Te vinden in de meettabel funderingspalen (Bijlage 3).
     palen: list[Paal]
 
-    # TODO calculate vloer and onderloopsheidscherm in issue #40,  - TAVM
-    vloer: Vloer | None = None
+    vloer: Vloer
     onderloopsheidscherm: Onderloopsheidscherm | None = None
 
     # Af te leiden uit de constructiebeschrijving (paragraaf 5.x) of doorsnedetekening.

--- a/src/tekstherkenning_ark/models/onderloopsheidscherm.py
+++ b/src/tekstherkenning_ark/models/onderloopsheidscherm.py
@@ -21,8 +21,6 @@ class Onderloopsheidscherm(BaseModel):
         opmerkingen: Eventuele aanvullende opmerkingen over het onderloopsheidscherm.
     """
 
-    # Te vinden in de constructiebeschrijving (paragraaf 5.x) of op de archieftekening.
-    is_aanwezig: bool | NietBeschikbaar
     gebreken: list[Gebrek] = []
     # Te vinden in de toestandstabel (figuur 1.11) of als 'algemeen' gebrek in de gebrekentabel (paragraaf 2.3 of 5.3.3).
     is_beschadigd: bool | None = None
@@ -32,15 +30,17 @@ class Onderloopsheidscherm(BaseModel):
     opmerkingen: str = ""
 
     @classmethod
-    def from_rakdeel_omschrijving(cls, omschrijving: RakdeelOmschrijving) -> Onderloopsheidscherm:
+    def from_rakdeel_omschrijving(cls, omschrijving: RakdeelOmschrijving) -> Onderloopsheidscherm | None:
         """Genereer een Onderloopsheidscherm model vanuit een RakdeelOmschrijving model.
 
         Args:
             omschrijving (RakdeelOmschrijving): Het RakdeelOmschrijving model.
 
         Returns:
-            Onderloopsheidscherm: Het gegenereerde Onderloopsheidscherm model.
+            Onderloopsheidscherm | None: Een leeg Onderloopsheidscherm model, of None als er geen onderloopsheidscherm is.
         """
-        return cls(
-            is_aanwezig=omschrijving.onderloopsheidscherm,
-        )
+
+        if not omschrijving.onderloopsheidscherm:
+            return cls()
+
+        return None

--- a/src/tekstherkenning_ark/models/onderloopsheidscherm.py
+++ b/src/tekstherkenning_ark/models/onderloopsheidscherm.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
 from pydantic import BaseModel
 
+from tekstherkenning_ark.enums import NietBeschikbaar
 from tekstherkenning_ark.models.gebrek import Gebrek
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tekstherkenning_ark.llm.rakdeel_omschrijving import RakdeelOmschrijving
 
 
 class Onderloopsheidscherm(BaseModel):
@@ -15,11 +22,25 @@ class Onderloopsheidscherm(BaseModel):
     """
 
     # Te vinden in de constructiebeschrijving (paragraaf 5.x) of op de archieftekening.
-    is_aanwezig: bool
+    is_aanwezig: bool | NietBeschikbaar
     gebreken: list[Gebrek] = []
     # Te vinden in de toestandstabel (figuur 1.11) of als 'algemeen' gebrek in de gebrekentabel (paragraaf 2.3 of 5.3.3).
     is_beschadigd: bool | None = None
     # Te vinden in de uitleg bij het algemene gebrek in de gebrekentabel (paragraaf 2.3 of 5.3.3).
-    is_meerdere_locaties: bool | None = None
+    is_meerdere_locaties: bool | None = None  # TODO
     # Te vinden in de tekst van de constructiebeschrijving of de gebrekentabel.
     opmerkingen: str = ""
+
+    @classmethod
+    def from_rakdeel_omschrijving(cls, omschrijving: RakdeelOmschrijving) -> Onderloopsheidscherm:
+        """Genereer een Onderloopsheidscherm model vanuit een RakdeelOmschrijving model.
+
+        Args:
+            omschrijving (RakdeelOmschrijving): Het RakdeelOmschrijving model.
+
+        Returns:
+            Onderloopsheidscherm: Het gegenereerde Onderloopsheidscherm model.
+        """
+        return cls(
+            is_aanwezig=omschrijving.onderloopsheidscherm,
+        )

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -4,7 +4,9 @@ from typing import Type, TypeVar
 from pydantic import BaseModel
 from azure.ai.documentintelligence.models import DocumentParagraph, DocumentTable
 
+from tekstherkenning_ark.models.onderloopsheidscherm import Onderloopsheidscherm
 from tekstherkenning_ark.models.paal import Paal
+from tekstherkenning_ark.models.vloer import Vloer
 from tekstherkenning_ark.smart_document import RakdeelSectie
 from tekstherkenning_ark.llm.rakdeel_omschrijving import RakdeelOmschrijving
 from tekstherkenning_ark.models.bovenbouw import Bovenbouw
@@ -78,8 +80,8 @@ class Rakdeel(BaseModel):
         onderbouw = Onderbouw(
             palen=palen,
             kespen=kespen,
-            # onderloopsheidscherm=rakdeel_omschrijving.onderloopsheidscherm, # TODO
-            # vloer=rakdeel_omschrijving.materiaal_vloer,
+            onderloopsheidscherm=Onderloopsheidscherm.from_rakdeel_omschrijving(rakdeel_omschrijving),
+            vloer=Vloer.from_rakdeel_omschrijving(rakdeel_omschrijving),
             materiaal=rakdeel_omschrijving.materiaal_onderbouw,
         )
         bovenbouw = Bovenbouw(

--- a/src/tekstherkenning_ark/models/vloer.py
+++ b/src/tekstherkenning_ark/models/vloer.py
@@ -1,6 +1,14 @@
+from __future__ import annotations
+
 from pydantic import BaseModel
 
+from tekstherkenning_ark.enums import MateriaalVloer
 from tekstherkenning_ark.models.gebrek import Gebrek
+
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tekstherkenning_ark.llm.rakdeel_omschrijving import RakdeelOmschrijving
 
 
 class Vloer(BaseModel):
@@ -16,11 +24,11 @@ class Vloer(BaseModel):
     """
 
     # Te vinden in de gebrekentabel (paragraaf 2.3 of 5.3.3) als 'algemeen' gebrek.
-    is_beschadigd: bool
+    is_beschadigd: bool | None = None
     gebreken: list[Gebrek] = []
 
     # Af te leiden uit de constructiebeschrijving (paragraaf 5.x) of doorsnedetekening.
-    materiaal: str
+    materiaal: MateriaalVloer
 
     # Te vinden in de constructiebeschrijving (paragraaf 5.x) of af te leiden uit de doorsnedetekening.
     bovenkant_vloer_cm_tov_nap: float | None = None
@@ -29,3 +37,18 @@ class Vloer(BaseModel):
 
     # Te vinden in de tekst van de constructiebeschrijving of de gebrekentabel.
     opmerkingen: str = ""
+
+    @classmethod
+    def from_rakdeel_omschrijving(cls, omschrijving: RakdeelOmschrijving) -> Vloer:
+        """Genereer een Vloer model vanuit een RakdeelOmschrijving model.
+
+        Args:
+            omschrijving (RakdeelOmschrijving): Het RakdeelOmschrijving model.
+
+        Returns:
+            Vloer: Het gegenereerde Vloer model.
+        """
+        return cls(
+            materiaal=omschrijving.materiaal_vloer,
+            bovenkant_vloer_cm_tov_nap=omschrijving.bovenkant_vloer_cm,
+        )


### PR DESCRIPTION
fixes #40 

- implementeer `from_rakdeel_omschrijving` classmethod voor `Vloer` en `Onderloopsheidscherm`
- `Onderloopsheidscherm` is `None` als `rakdeel_omschrijving.onderloopsheidscherm == False`