### PR TITLE
remove duplicate code

### DIFF
--- a/src/tekstherkenning_ark/models/rak_base_model.py
+++ b/src/tekstherkenning_ark/models/rak_base_model.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
-from typing import get_args, get_origin, Union
+from typing import TypeVar, get_args, get_origin, Union
 from pydantic import BaseModel
 
 from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
+
+T = TypeVar("T", Gebrek, OnverwachtResultaat)
 
 
 class RakBaseModel(BaseModel):
@@ -47,6 +49,12 @@ class RakBaseModel(BaseModel):
             cls.__annotations__ = new_annotations
 
     @property
+    def onverwachte_resultaten(self) -> list[OnverwachtResultaat]:
+        """Return a list of all OnverwachtResultaat objects in this model"""
+
+        return [value for value in self.__dict__.values() if isinstance(value, OnverwachtResultaat)]
+
+    @property
     def children(self) -> list[RakBaseModel]:
         """Return a list of child models that are a subclass of RakModelBase."""
         children = []
@@ -60,7 +68,7 @@ class RakBaseModel(BaseModel):
 
         return children
 
-    def _get_alle_gebreken_with_path(self, prefix: str = "") -> list[tuple[str, Gebrek]]:
+    def _get_all_with_path(self, obj_type: T, prefix: str = "") -> list[tuple[str, T]]:
         """Helper method to recursively collect gebreken with their identifier paths.
 
         Args:
@@ -71,47 +79,18 @@ class RakBaseModel(BaseModel):
         """
         current_path = f"{prefix}/{self.identifier}" if prefix else self.identifier
 
-        # Add gebreken from this model
-        result = [(current_path, gebrek) for gebrek in self.gebreken]
+        # Add objects from this model
+        if obj_type == Gebrek:
+            obj_list = self.gebreken
+        elif obj_type == OnverwachtResultaat:
+            obj_list = self.onverwachte_resultaten
+        else:
+            raise ValueError(f"obj_type should be either `Gebrek` or `OnverwachtResultaat`, not '{obj_type}'")
+        result = [(current_path, gebrek) for gebrek in obj_list]
 
         # Recursively collect from children
         for child in self.children:
-            result.extend(child._get_alle_gebreken_with_path(current_path))
-
-        return result
-
-    @property
-    def alle_gebreken(self) -> list[tuple[str, Gebrek]]:
-        """Return a list of tuples (path, gebrek) for all Gebrek objects in this model and its children.
-
-        The path is a slash-separated string of identifiers showing the hierarchy,
-        e.g., 'raknaam/rakdeel_id/onderbouw/paal_nummer'.
-        """
-        return self._get_alle_gebreken_with_path()
-
-    @property
-    def onverwachte_resultaten(self) -> list[OnverwachtResultaat]:
-        """Return a list of all OnverwachtResultaat objects in this model"""
-
-        return [value for value in self.__dict__.values() if isinstance(value, OnverwachtResultaat)]
-
-    def _get_alle_onverwachte_resultaten_with_path(self, prefix: str = "") -> list[tuple[str, OnverwachtResultaat]]:
-        """Helper method to recursively collect onverwachte resultaten with their identifier paths.
-
-        Args:
-            prefix: The parent path prefix to prepend to this object's identifier.
-
-        Returns:
-            List of tuples containing (full_path, onverwacht_resultaat) for all onverwachte resultaten.
-        """
-        current_path = f"{prefix}/{self.identifier}" if prefix else self.identifier
-
-        # Add onverwachte resultaten from this model
-        result = [(current_path, onverwacht) for onverwacht in self.onverwachte_resultaten]
-
-        # Recursively collect from children
-        for child in self.children:
-            result.extend(child._get_alle_onverwachte_resultaten_with_path(current_path))
+            result.extend(child._get_all_with_path(obj_type=obj_type, prefix=current_path))
 
         return result
 
@@ -122,4 +101,13 @@ class RakBaseModel(BaseModel):
         The path is a slash-separated string of identifiers showing the hierarchy,
         e.g., 'raknaam/rakdeel_id/bovenbouw/metselwerk'.
         """
-        return self._get_alle_onverwachte_resultaten_with_path()
+        return self._get_all_with_path(obj_type=OnverwachtResultaat)
+
+    @property
+    def alle_gebreken(self) -> list[tuple[str, Gebrek]]:
+        """Return a list of tuples (path, gebrek) for all Gebrek objects in this model and its children.
+
+        The path is a slash-separated string of identifiers showing the hierarchy,
+        e.g., 'raknaam/rakdeel_id/onderbouw/paal_nummer'.
+        """
+        return self._get_all_with_path(obj_type=Gebrek)

--- a/src/tekstherkenning_ark/models/rak_base_model.py
+++ b/src/tekstherkenning_ark/models/rak_base_model.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TypeVar, get_args, get_origin, Union
+from typing import Type, TypeVar, get_args, get_origin, Union
 from pydantic import BaseModel
 
 from tekstherkenning_ark.models.gebrek import Gebrek
@@ -68,7 +68,7 @@ class RakBaseModel(BaseModel):
 
         return children
 
-    def _get_all_with_path(self, obj_type: T, prefix: str = "") -> list[tuple[str, T]]:
+    def _get_all_with_path(self, obj_type: Type[T], prefix: str = "") -> list[tuple[str, T]]:
         """Helper method to recursively collect gebreken with their identifier paths.
 
         Args:


### PR DESCRIPTION
fixes #67 

Trekt `RakBaseModel`'s `_get_alle_gebreken_with_path` en `_get_alle_onverwachte_resultaten_with_path` samen tot één methode `_get_all_with_path`