### PR TITLE
rework to extract rows in smartdocument

### DIFF
--- a/scripts/rak_to_excel.py
+++ b/scripts/rak_to_excel.py
@@ -17,17 +17,17 @@ from pathlib import Path
 
 from tekstherkenning_ark import constants
 from tekstherkenning_ark.models.rak import Rak
-from tekstherkenning_ark.smart_document import SmartDocument
+from tekstherkenning_ark.document.smart_document import SmartDocument
 
 
 def main():
     """Hoofdfunctie voor het exporteren van Rak data naar Excel."""
     pdf_rapporten = [file for file in (constants.DATA_DIR / "duikrapporten").glob("*.pdf")]
-    docs = [SmartDocument.from_pdf(file) for file in pdf_rapporten[1:4]]
+    docs = [SmartDocument.from_pdf(file) for file in pdf_rapporten]
     for doc in docs:
         if not "boor" in doc.pdf_path.stem.lower():
             print(f"Genereren van Rak object voor {doc.pdf_path.name}...")
-            rak = Rak.from_smart_document(doc)
+            rak = Rak.from_smart_document(doc, use_caching=False)
             print("Exporteren naar Excel...")
             export_pad = rak.to_excel()
             print(f"Klaar! Bestand opgeslagen: {export_pad}")

--- a/src/tekstherkenning_ark/document/rakdeelsectie.py
+++ b/src/tekstherkenning_ark/document/rakdeelsectie.py
@@ -29,15 +29,13 @@ class RakdeelSectie:
     gebreken_tabel: list[list[str]]
 
     @classmethod
-    def from_smart_document(cls, secties: list[Sectie], index: int) -> RakdeelSectie:
+    def from_smart_document(cls, secties: list[Sectie]) -> RakdeelSectie:
         """Maak een rakdeel sectie uit SmartDocument-secties.
 
         Parameters
         ----------
         secties : list[Sectie]
             Lijst met alle secties uit het SmartDocument.
-        index : int
-            Index van de sectie die de constructie beschrijft.
 
         Returns
         -------
@@ -56,16 +54,17 @@ class RakdeelSectie:
 
         for sectie in secties:
             # if sectie titel contains "constructie [a-z]" then it is the base rakdeelsectie
-            if get_constructienaam(sectie.titel):
+            if get_constructienaam(sectie.titel) and not constructie_naam:
                 constructie_naam = get_constructienaam(sectie.titel) or ""
                 beschrijving = sectie.inhoud
-            elif "toestand" in sectie.titel.lower():
+            elif "toestand" in sectie.titel.lower() and not toestand_tabel:
                 toestand_tabel = RakdeelSectie._get_toestand_tabel(sectie.tabellen)
-            elif "gebrek" in sectie.titel.lower():
+            elif "gebrek" in sectie.titel.lower() and not gebreken_tabel:
                 gebreken_tabel = RakdeelSectie._get_gebreken_tabel(sectie.tabellen)
+                break
 
         return cls(
-            constructie_naam=constructie_naam,
+            constructie_naam=constructie_naam or "Onbekende constructie",
             beschrijving=beschrijving,
             toestand_tabel=toestand_tabel,
             gebreken_tabel=gebreken_tabel,

--- a/src/tekstherkenning_ark/document/rakdeelsectie.py
+++ b/src/tekstherkenning_ark/document/rakdeelsectie.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+from azure.ai.documentintelligence.models import DocumentTable, DocumentParagraph
+
+from tekstherkenning_ark.document.sectie import Sectie
+from tekstherkenning_ark.utils import get_constructienaam, get_table_content, remove_titel_rows, remove_invalid_rows
+
+
+@dataclass
+class RakdeelSectie:
+    """Representeert een rakdeel sectie met constructie informatie.
+
+    Attributes
+    ----------
+    constructie_naam : str
+        Naam van de constructie.
+    beschrijving : list[DocumentParagraph]
+        Beschrijvende paragrafen.
+    toestand_tabel : list[list[str]]
+        Tabelinhoud met toestandsinformatie.
+    gebreken_tabel : list[list[str]]
+        Tabelinhoud met gebrekeninformatie.
+    """
+
+    constructie_naam: str
+    beschrijving: list[DocumentParagraph]
+    toestand_tabel: list[list[str]]
+    gebreken_tabel: list[list[str]]
+
+    @classmethod
+    def from_smart_document(cls, secties: list[Sectie], index: int) -> RakdeelSectie:
+        """Maak een rakdeel sectie uit SmartDocument-secties.
+
+        Parameters
+        ----------
+        secties : list[Sectie]
+            Lijst met alle secties uit het SmartDocument.
+        index : int
+            Index van de sectie die de constructie beschrijft.
+
+        Returns
+        -------
+        RakdeelSectie
+            Geconstrueerde rakdeel sectie met beschrijving en tabellen.
+
+        Raises
+        ------
+        ValueError
+            Als de index buiten bereik valt.
+        """
+        constructie_naam = ""
+        beschrijving = []
+        toestand_tabel = []
+        gebreken_tabel = []
+
+        for sectie in secties:
+            # if sectie titel contains "constructie [a-z]" then it is the base rakdeelsectie
+            if get_constructienaam(sectie.titel):
+                constructie_naam = get_constructienaam(sectie.titel) or ""
+                beschrijving = sectie.inhoud
+            elif "toestand" in sectie.titel.lower():
+                toestand_tabel = RakdeelSectie._get_toestand_tabel(sectie.tabellen)
+            elif "gebrek" in sectie.titel.lower():
+                gebreken_tabel = RakdeelSectie._get_gebreken_tabel(sectie.tabellen)
+
+        return cls(
+            constructie_naam=constructie_naam,
+            beschrijving=beschrijving,
+            toestand_tabel=toestand_tabel,
+            gebreken_tabel=gebreken_tabel,
+        )
+
+    @staticmethod
+    def _get_toestand_tabel(list_of_tables: list[DocumentTable]) -> list[list[str]]:
+        """Helper om de juiste toestand tabel te vinden uit een lijst van tabellen."""
+        rows: list[list[str]] = []
+
+        for tabel in list_of_tables:
+            if tabel.cells:
+                rows.extend(get_table_content(tabel))
+        rows_wo_header = remove_titel_rows(rows)
+        rows_cleaned = remove_invalid_rows(rows_wo_header)
+        return rows_cleaned
+
+    @staticmethod
+    def _get_gebreken_tabel(list_of_tables: list[DocumentTable]) -> list[list[str]]:
+        """Helper om de juiste gebreken tabel te vinden uit een lijst van tabellen."""
+        rows: list[list[str]] = []
+        for tabel in list_of_tables:
+            if tabel.column_count == 3 and tabel.cells:
+                rows.extend(get_table_content(tabel))
+        rows_wo_header = remove_titel_rows(rows)
+        rows_cleaned = remove_invalid_rows(rows_wo_header)
+        return rows_cleaned

--- a/src/tekstherkenning_ark/document/sectie.py
+++ b/src/tekstherkenning_ark/document/sectie.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+
+from azure.ai.documentintelligence.models import DocumentTable, DocumentParagraph
+
+
+@dataclass
+class Sectie:
+    """Een sectie in het document met titel, paragrafen en tabellen.
+
+    Attributes
+    ----------
+    titel : str
+        De titel van de sectie (section heading).
+    inhoud : list[DocumentParagraph]
+        Lijst van paragrafen in de sectie.
+    tabellen : list[DocumentTable]
+        Lijst van tabellen die bij deze sectie horen.
+    heading_offset : int
+        Offset van de section heading in het originele document.
+    """
+
+    titel: str
+    inhoud: list[DocumentParagraph] = field(default_factory=list)
+    tabellen: list[DocumentTable] = field(default_factory=list)
+    heading_offset: int = 0
+
+    def full_text(self) -> str:
+        """Combineert alle tekstuele inhoud van de sectie."""
+        return "\n".join(p.content for p in self.inhoud)

--- a/src/tekstherkenning_ark/document/smart_document.py
+++ b/src/tekstherkenning_ark/document/smart_document.py
@@ -118,7 +118,7 @@ class SmartDocument:
         rakdeel_secties = []
         for i, sectie in enumerate(self.sections):
             if get_constructienaam(sectie.titel):
-                rakdeel_secties.append(RakdeelSectie.from_smart_document(self.sections, i))
+                rakdeel_secties.append(RakdeelSectie.from_smart_document(self.sections[i:]))
         return rakdeel_secties
 
     def get_meettabel_houtmonsters(self) -> list[list[str]]:

--- a/src/tekstherkenning_ark/document/smart_document.py
+++ b/src/tekstherkenning_ark/document/smart_document.py
@@ -3,10 +3,22 @@ from dataclasses import dataclass, field
 import os
 from pathlib import Path
 import pickle
+from typing import Callable
 
 
 from tekstherkenning_ark import constants
 from tekstherkenning_ark.constants import DATA_DIR
+from tekstherkenning_ark.utils import (
+    get_constructienaam,
+    get_paal_id,
+    get_kesp_id,
+    get_rak_id,
+    get_table_content,
+    remove_titel_rows,
+    remove_invalid_rows,
+)
+from tekstherkenning_ark.document.sectie import Sectie
+from tekstherkenning_ark.document.rakdeelsectie import RakdeelSectie
 from azure.ai.documentintelligence.models import AnalyzeResult, DocumentTable, DocumentParagraph
 from azure.ai.documentintelligence import DocumentIntelligenceClient
 from azure.core.credentials import AzureKeyCredential
@@ -14,58 +26,11 @@ from io import BytesIO
 
 from dotenv import load_dotenv
 from tekstherkenning_ark.logger import get_logger
+import re
 
 load_dotenv()
 
 logger = get_logger(__name__)
-
-
-@dataclass
-class Sectie:
-    """Een sectie in het document met titel, paragrafen en tabellen.
-
-    Attributes
-    ----------
-    titel : str
-        De titel van de sectie (section heading).
-    inhoud : list[DocumentParagraph]
-        Lijst van paragrafen in de sectie.
-    tabellen : list[DocumentTable]
-        Lijst van tabellen die bij deze sectie horen.
-    heading_offset : int
-        Offset van de section heading in het originele document.
-    """
-
-    titel: str
-    inhoud: list[DocumentParagraph] = field(default_factory=list)
-    tabellen: list[DocumentTable] = field(default_factory=list)
-    heading_offset: int = 0
-
-    def full_text(self) -> str:
-        """Combineert alle tekstuele inhoud van de sectie."""
-        return "\n".join(p.content for p in self.inhoud)
-
-
-@dataclass
-class RakdeelSectie:
-    """Representeert een rakdeel sectie met constructie informatie.
-
-    Attributes
-    ----------
-    constructie_naam : str
-        Naam van de constructie.
-    beschrijving : list[DocumentParagraph]
-        Beschrijvende paragrafen.
-    toestand_tabel : list[DocumentTable]
-        Tabellen met toestandsinformatie.
-    gebreken_tabel : list[DocumentTable]
-        Tabellen met gebrekeninformatie.
-    """
-
-    constructie_naam: str
-    beschrijving: list[DocumentParagraph]
-    toestand_tabel: list[DocumentTable]
-    gebreken_tabel: list[DocumentTable]
 
 
 @dataclass
@@ -134,6 +99,98 @@ class SmartDocument:
         doc._parse_document()
         return doc
 
+    def _get_table_min_offset(self, table: DocumentTable) -> int:
+        """Bepaal de minimale offset van een tabel."""
+        if not table.cells:
+            return 0
+
+        min_offset = min(cell.spans[0].offset for cell in table.cells if cell.spans)
+        return min_offset
+
+    def get_rakdeel_secties(self) -> list[RakdeelSectie]:
+        """Haal de secties op die rakdelen beschrijven.
+
+        Returns
+        -------
+        list[RakdeelSectie]
+            Lijst van rakdeel secties met constructie informatie.
+        """
+        rakdeel_secties = []
+        for i, sectie in enumerate(self.sections):
+            if get_constructienaam(sectie.titel):
+                rakdeel_secties.append(RakdeelSectie.from_smart_document(self.sections, i))
+        return rakdeel_secties
+
+    def get_meettabel_houtmonsters(self) -> list[list[str]]:
+        """Haal de meettabel voor houtmonsters op.
+
+        Returns
+        -------
+        list[list[str]]
+            Tabelinhoud met houtmonster metingen.
+        """
+        for sectie in self.sections:
+            if "meettabel houtmonsters" in sectie.titel.lower() and sectie.tabellen:
+                rows: list[list[str]] = []
+                for tabel in sectie.tabellen:
+                    rows.extend(get_table_content(tabel))
+                rows_wo_header = remove_titel_rows(rows)
+                rows_valid = remove_invalid_rows(rows_wo_header)
+                rows_cleaned = [
+                    row for row in rows_valid if all(x not in row[0].lower() for x in ["meettabel", "[rak]"])
+                ]
+                return rows_cleaned
+        return []
+
+    def get_meettabel_fundering_paal(self) -> list[list[str]]:
+        """Haal de meettabel voor palen op.
+
+        Returns
+        -------
+        list[list[str]]
+            Tabelinhoud waar >50% van eerste kolom een geldig paal ID bevat.
+        """
+        for sectie in self.sections:
+            if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
+                rows: list[list[str]] = []
+                for tabel in sectie.tabellen:
+                    if self._is_table_type_by_id_func(tabel, get_paal_id):
+                        rows.extend(get_table_content(tabel))
+                rows_wo_header = remove_titel_rows(rows)
+                rows_valid = remove_invalid_rows(rows_wo_header)
+                rows_cleaned = [
+                    row for row in rows_valid if all(x not in row[0].lower() for x in ["meettabel", "[rak]"])
+                ]
+                return rows_cleaned
+        return []
+
+    def get_meettabel_fundering_kesp(self) -> list[list[str]]:
+        """Haal de meettabel voor kespen op.
+
+        Returns
+        -------
+        list[list[str]]
+            Tabelinhoud waar >50% van eerste kolom een geldig kesp ID bevat.
+        """
+        for sectie in self.sections:
+            if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
+                rows: list[list[str]] = []
+                for tabel in sectie.tabellen:
+                    if self._is_table_type_by_id_func(tabel, get_kesp_id):
+                        rows.extend(get_table_content(tabel))
+                rows_wo_header = remove_titel_rows(rows)
+                rows_cleaned = remove_invalid_rows(rows_wo_header)
+                return rows_cleaned
+        return []
+
+    def get_raknaam(self) -> str:
+        for tabel in self.sections[0].tabellen:
+            if tabel.column_count == 2:
+                for cell in tabel.cells:
+                    if get_rak_id(cell.content):
+                        return get_rak_id(cell.content) or cell.content.strip()
+        return "Onbekend Rak"
+
     def _parse_document(self) -> None:
         """Parse het AnalyzeResult en splits het op in secties."""
 
@@ -201,89 +258,34 @@ class SmartDocument:
             if not assigned and self.sections:
                 self.sections[-1].tabellen.append(table)
 
-    def _get_table_min_offset(self, table: DocumentTable) -> int:
-        """Bepaal de minimale offset van een tabel."""
-        if not table.cells:
-            return 0
+    def _is_table_type_by_id_func(
+        self, tabel: DocumentTable, id_func: Callable[[str], str | None], threshold: float = 0.5
+    ) -> bool:
+        """Check of een tabel bij een type hoort op basis van een ID-extractie functie.
 
-        min_offset = min(cell.spans[0].offset for cell in table.cells if cell.spans)
-        return min_offset
-
-    def get_rakdeel_secties(self) -> list[RakdeelSectie]:
-        """Haal de secties op die rakdelen beschrijven.
-
-        Returns
-        -------
-        list[RakdeelSectie]
-            Lijst van rakdeel secties met constructie informatie.
-        """
-        rakdeel_secties = []
-        for i, sectie in enumerate(self.sections):
-            if "Constructie" in sectie.titel:
-                titel = sectie.titel.split(" ")[1:]
-                omschrijving = self.sections[i].inhoud
-                toestand_tabellen = self.sections[i + 2].tabellen
-                gebreken_tabellen = self.sections[i + 3].tabellen
-                rakdeel_secties.append(
-                    RakdeelSectie(
-                        constructie_naam=" ".join(titel),
-                        beschrijving=omschrijving,
-                        toestand_tabel=toestand_tabellen,
-                        gebreken_tabel=gebreken_tabellen,
-                    )
-                )
-        return rakdeel_secties
-
-    def get_meettabel_houtmonsters(self) -> list[DocumentTable]:
-        """Haal de meettabel voor houtmonsters op.
+        Parameters
+        ----------
+        tabel : DocumentTable
+            De tabel om te controleren.
+        id_func : callable
+            Functie die een string neemt en een ID of None teruggeeft (bijv. get_paal_id).
+        threshold : float
+            Minimale fractie van cellen die moeten matchen.
 
         Returns
         -------
-        list[DocumentTable]
-            Lijst van tabellen met houtmonster metingen.
+        bool
+            True als de tabel voldoet aan het type.
         """
-        for sectie in self.sections:
-            if "meettabel houtmonsters" in sectie.titel.lower() and sectie.tabellen:
-                return sectie.tabellen
-        return []
-
-    def _is_table_type_by_first_column(self, tabel: DocumentTable, prefix: str, threshold: float = 0.5) -> bool:
-        """Check of een tabel bij een type hoort op basis van eerste kolom prefix."""
-        if tabel.column_count <= 10:
+        if not tabel.cells:
             return False
 
         first_col_cells = [cell.content for cell in tabel.cells if cell.column_index == 0]
         if not first_col_cells:
             return False
 
-        matching_cells = sum(1 for cell in first_col_cells if cell.startswith(prefix))
+        matching_cells = sum(1 for cell in first_col_cells if id_func(cell) is not None)
         return (matching_cells / len(first_col_cells)) > threshold
-
-    def get_meettabel_fundering_paal(self) -> list[DocumentTable]:
-        """Haal de meettabel voor palen op.
-
-        Returns
-        -------
-        list[DocumentTable]
-            Tabellen waar >50% van eerste kolom met 'P' begint.
-        """
-        for sectie in self.sections:
-            if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
-                return [tabel for tabel in sectie.tabellen if self._is_table_type_by_first_column(tabel, "P")]
-        return []
-
-    def get_meettabel_fundering_kesp(self) -> list[DocumentTable]:
-        """Haal de meettabel voor kespen op.
-
-        Returns
-        -------
-        list[DocumentTable]
-            Tabellen waar >50% van eerste kolom met 'K' begint.
-        """
-        for sectie in self.sections:
-            if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
-                return [tabel for tabel in sectie.tabellen if self._is_table_type_by_first_column(tabel, "K")]
-        return []
 
     def __repr__(self) -> str:
         section_summary = "\n".join(

--- a/src/tekstherkenning_ark/models/gebrek.py
+++ b/src/tekstherkenning_ark/models/gebrek.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import asyncio
 from typing import Literal
 from pydantic import BaseModel
-from azure.ai.documentintelligence.models import DocumentTable
 
 from tekstherkenning_ark.utils import (
     get_paal_id,
-    get_table_content,
     contains_kesp_id,
     contains_paal_id,
     is_algemeen_gebrek,
@@ -44,14 +42,13 @@ class Gebrek(BaseModel):
     figuurnummer: str | NietBeschikbaar
 
     @classmethod
-    async def from_doc_tables(cls, tables: list[DocumentTable]) -> list[Gebrek]:
-        """Maak een lijst van Gebrek instanties uit meerdere document tabellen.
+    async def from_doc_tables(cls, rows: list[list[str]]) -> list[Gebrek]:
+        """Maak een lijst van Gebrek instanties uit tabel rijen.
 
         Parameters
         ----------
-        tables : list[DocumentTable]
-            Lijst van DocumentTable objecten zoals teruggegeven door Azure Document Intelligence SDK
-            behorend bij de gebreken bijlage
+        rows : list[list[str]]
+            Lijst van tabel rijen als lijsten van strings.
 
         Returns
         -------
@@ -60,23 +57,15 @@ class Gebrek(BaseModel):
         """
         expected_header = ["Gebrekcodering", "Omschrijving", "Figuurnummer"]
 
-        gebrek_rows: list[list[str]] = []
-        for table in tables:
-            # Extraheer tabel inhoud als lijst van rijen
-            table_rows = get_table_content(table)
+        # Check header and filter content rows
+        if rows and rows[0] != expected_header:
+            logger.warning(
+                f"Onverwachte tabel header. Verwacht {expected_header}, kreeg {rows[0] if rows else 'leeg'}..."
+            )
+            return []
 
-            # Controleer header van eerste tabel
-            if (len(gebrek_rows) == 0 and table_rows[0] != expected_header) or len(table_rows[0]) < len(
-                expected_header
-            ):
-                logger.warning(
-                    f"Onverwachte tabel header. Verwacht {expected_header}, kreeg {table_rows[0]}, door naar volgende tabel..."
-                )
-                continue  # Ga door naar volgende tabel in plaats van een fout te gooien
-
-            # Sla header rijen over en voeg toe aan gebrek_rows
-            content_rows = [r for r in table_rows if r[0] != expected_header[0]]
-            gebrek_rows.extend(content_rows)
+        # Skip header row
+        gebrek_rows = [r for r in rows if r[0] != expected_header[0]]
 
         # Parsing logica om Gebrek instanties te maken
         list_gebreken = []

--- a/src/tekstherkenning_ark/models/houtmonster.py
+++ b/src/tekstherkenning_ark/models/houtmonster.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 from pydantic import BaseModel
 
-from azure.ai.documentintelligence.models import DocumentTable
-
 from tekstherkenning_ark import utils
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaatType, OnverwachtResultaat
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
@@ -56,31 +54,22 @@ class Houtmonster(RakBaseModel):
         return str(self.codering)
 
     @classmethod
-    def from_doc_tables(cls, tables: list[DocumentTable]) -> list[Houtmonster]:
-        """Parse and return a list of Houtmonster objects from a Azure Document
-        Intelligence DocumentTable object
+    def from_doc_tables(cls, rows: list[list[str]]) -> list[Houtmonster]:
+        """Parse and return a list of Houtmonster objects from table rows.
 
         Parameters
         ----------
-        tables : list[DocumentTable]
-            List of DocumentTable objects as returned by Azure Document Intelligence SDK
-            belonging to the `Houtmonster` bijlage
+        rows : list[list[str]]
+            List of table rows as lists of strings.
 
         Returns
         -------
-        dict[str, list[Houtmonster]]
-            A dictionary mapping constructie ID's to lists of Houtmonster objects containing information from the table
+        list[Houtmonster]
+            A list of Houtmonster objects containing information from the table.
         """
 
-        houtmonster_rows: list[list[str]] = []
-        for table in tables:
-
-            # Extract table content as list of rows
-            table_rows = utils.get_table_content(table)
-
-            # Skip header rows and add to paal_rows
-            content_rows = [r for r in table_rows if utils.is_houtmonster_id(r[0])]
-            houtmonster_rows.extend(content_rows)
+        # Skip header rows and filter to houtmonster rows
+        houtmonster_rows = [r for r in rows if utils.is_houtmonster_id(r[0])]
 
         # Parse each row into a Houtmonster object
         houtmonster_list = [cls.from_houtmonster_table_row(row) for row in houtmonster_rows]
@@ -123,7 +112,7 @@ class Houtmonster(RakBaseModel):
 
 if __name__ == "__main__":
 
-    from tekstherkenning_ark.smart_document import SmartDocument
+    from tekstherkenning_ark.document.smart_document import SmartDocument
     from tekstherkenning_ark import constants
 
     doc = SmartDocument.from_pdf(constants.TEST_PDF_PATH)

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -4,7 +4,6 @@ from tekstherkenning_ark import utils
 from tekstherkenning_ark.enums import NietBeschikbaar
 from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
-from azure.ai.documentintelligence.models import DocumentTable
 from tekstherkenning_ark.logger import get_logger
 
 logger = get_logger(__name__)
@@ -62,15 +61,13 @@ class Kesp(RakBaseModel):
         return self.kesp_nummer
 
     @classmethod
-    def from_doc_tables(cls, tables: list[DocumentTable]) -> dict[str, list[Kesp]]:
-        """Parse and return a list of Kesp objects from a Azure Doc
-        Intelligence DocumentTable object
+    def from_doc_tables(cls, rows: list[list[str]]) -> dict[str, list[Kesp]]:
+        """Parse and return a list of Kesp objects from table rows.
 
         Parameters
         ----------
-        tables : list[DocumentTable]
-            List of DocumentTable objects as returned by Azure Document Intelligence SDK
-            belonging to the `Kespen` bijlage
+        rows : list[list[str]]
+            List of table rows as lists of strings.
 
         Returns
         -------
@@ -78,17 +75,10 @@ class Kesp(RakBaseModel):
             A dictionary mapping constructie ID's to lists of Kesp objects containing information from the table
         """
 
-        kesp_rows: list[list[str]] = []
-        for table in tables:
+        # Skip header rows and filter to kesp rows
+        kesp_rows = [r for r in rows if utils.contains_kesp_id(r[0])]
 
-            # Extract table content as list of rows
-            table_rows = utils.get_table_content(table)
-
-            # Skip header rows and add to paal_rows
-            content_rows = [r for r in table_rows if utils.contains_kesp_id(r[0])]
-            kesp_rows.extend(content_rows)
-
-        # Parse each row into a Paal object
+        # Parse each row into a Kesp object
         kesp_dict: dict[str, list[Kesp]] = {}
         current_constructie_id = ""
 

--- a/src/tekstherkenning_ark/models/paal.py
+++ b/src/tekstherkenning_ark/models/paal.py
@@ -6,7 +6,6 @@ from tekstherkenning_ark.enums import MateriaalOnderbouw, SchoorStand, NietBesch
 from tekstherkenning_ark.models.gebrek import Gebrek, Scheefstand
 from tekstherkenning_ark.models.houtmonster import Houtmonster
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
-from azure.ai.documentintelligence.models import DocumentTable
 from tekstherkenning_ark.logger import get_logger
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
 
@@ -100,15 +99,13 @@ class Paal(RakBaseModel):
         return int(self.paal_nummer.split(".")[1])
 
     @classmethod
-    def from_doc_tables(cls, tables: list[DocumentTable]) -> dict[str, list[Paal]]:
-        """Parse and return a list of Paal objects from a Azure Doc
-        Intelligence DocumentTable object
+    def from_doc_tables(cls, rows: list[list[str]]) -> dict[str, list[Paal]]:
+        """Parse and return a list of Paal objects from table rows.
 
         Parameters
         ----------
-        tables : list[DocumentTable]
-            List of DocumentTable objects as returned by Azure Document Intelligence SDK
-            belonging to the `Palen` bijlage
+        rows : list[list[str]]
+            List of table rows as lists of strings.
 
         Returns
         -------
@@ -116,15 +113,8 @@ class Paal(RakBaseModel):
             A dictionary mapping constructie ID's to lists of Paal objects containing information from the table
         """
 
-        paal_rows: list[list[str]] = []
-        for table in tables:
-
-            # Extract table content as list of rows
-            table_rows = utils.get_table_content(table)
-
-            # Skip header rows and add to paal_rows
-            content_rows = [r for r in table_rows if utils.contains_paal_id(r[0])]
-            paal_rows.extend(content_rows)
+        # Skip header rows and filter to paal rows
+        paal_rows = [r for r in rows if utils.contains_paal_id(r[0])]
 
         # Parse each row into a Paal object
         paal_dict: dict[str, list[Paal]] = {}
@@ -139,7 +129,7 @@ class Paal(RakBaseModel):
             constructie_id_col_val = utils.clean_string(row[16])
 
             if constructie_id_col_val != "":
-                current_constructie_id = constructie_id_col_val
+                current_constructie_id = constructie_id_col_val  # TODO: dit gaat niet goed bij palen waar de rakdeelnaam boven de palen staat
 
                 if current_constructie_id not in paal_dict:
                     paal_dict[current_constructie_id] = []
@@ -198,7 +188,7 @@ class Paal(RakBaseModel):
 
 if __name__ == "__main__":
 
-    from tekstherkenning_ark.smart_document import SmartDocument
+    from tekstherkenning_ark.document.smart_document import SmartDocument
     from tekstherkenning_ark import constants
 
     doc = SmartDocument.from_pdf(constants.TEST_PDF_PATH)

--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -16,7 +16,7 @@ from tekstherkenning_ark.models.paal import Paal
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
 from tekstherkenning_ark.models.rakdeel import Rakdeel
 from tekstherkenning_ark.models.gebrek import Gebrek
-from tekstherkenning_ark.smart_document import SmartDocument
+from tekstherkenning_ark.document.smart_document import SmartDocument
 from tekstherkenning_ark.logger import get_logger
 from tekstherkenning_ark.utils import get_rak_id
 
@@ -221,7 +221,7 @@ class Rak(RakBaseModel):
             rak_instance = pickle.loads(cache_file.read_bytes())
             return rak_instance
 
-        raknaam = get_rak_id(doc.pdf_path.stem) or "onbekend_rak"
+        raknaam = doc.get_raknaam()
 
         # Laad palen, kespen en houtmonsters uit tabellen
         paal_tables = doc.get_meettabel_fundering_paal()

--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
 
     doc = SmartDocument.from_pdf(constants.TEST_PDF_PATH)
 
-    rak = Rak.from_smart_document(doc)
+    rak = Rak.from_smart_document(doc, use_caching=False)
 
     for rd in rak.rakdelen:
         print(rd.rakdeel_id)

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Type, TypeVar
 
-from azure.ai.documentintelligence.models import DocumentParagraph, DocumentTable
+from azure.ai.documentintelligence.models import DocumentParagraph
 
 from tekstherkenning_ark import utils
 from tekstherkenning_ark.enums import NietBeschikbaar
@@ -11,7 +11,7 @@ from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
 from tekstherkenning_ark.models.paal import Paal
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
 from tekstherkenning_ark.models.vloer import Vloer
-from tekstherkenning_ark.smart_document import RakdeelSectie
+from tekstherkenning_ark.document.smart_document import RakdeelSectie
 from tekstherkenning_ark.llm.rakdeel_omschrijving import RakdeelOmschrijving
 from tekstherkenning_ark.models.bovenbouw import Bovenbouw
 from tekstherkenning_ark.models.gebrek import (
@@ -24,7 +24,6 @@ from tekstherkenning_ark.models.gebrek import (
 )
 from tekstherkenning_ark.models.onderbouw import Onderbouw
 from tekstherkenning_ark.models.kesp import Kesp
-from tekstherkenning_ark.smart_document import RakdeelSectie
 from tekstherkenning_ark.utils import contains_kesp_id, get_kesp_id, get_paal_id
 from tekstherkenning_ark.logger import get_logger
 
@@ -93,7 +92,7 @@ class Rakdeel(RakBaseModel):
         onderdeel_is_aangetast = cls.from_toestandbepaling_table(section.toestand_tabel)
 
         # Parse gebrekentabel
-        gebreken = await Gebrek.from_doc_tables(tables=section.gebreken_tabel)
+        gebreken = await Gebrek.from_doc_tables(rows=section.gebreken_tabel)
 
         # Verkrijg palen en kespen voor dit rakdeel
         palen = cls.get_for_constructie_naam(section.constructie_naam, palen_dict)
@@ -138,18 +137,12 @@ class Rakdeel(RakBaseModel):
 
     @staticmethod
     def from_toestandbepaling_table(
-        tables: list[DocumentTable],
+        rows: list[list[str]],
     ) -> dict[str, bool | NietBeschikbaar | OnverwachtResultaat]:
         expected_headers = ["Constructieonderdeel", "Aangetast"]
-        constructieonderdeel_rows: list[list[str]] = []
-        for table in tables:
 
-            # Extract table content as list of rows
-            table_rows = utils.get_table_content(table)
-
-            # Skip header rows and add to paal_rows
-            content_rows = [r for r in table_rows if r[0] != expected_headers[0]]
-            constructieonderdeel_rows.extend(content_rows)
+        # Skip header rows
+        constructieonderdeel_rows = [r for r in rows if r and r[0] != expected_headers[0]]
 
         dict_toestandsbepaling: dict[str, bool | NietBeschikbaar | OnverwachtResultaat] = {}
         if len(constructieonderdeel_rows) == 2:

--- a/src/tekstherkenning_ark/utils.py
+++ b/src/tekstherkenning_ark/utils.py
@@ -10,6 +10,7 @@ from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat,
 PAAL_ID_PATTERN = r"\bP\d+\.\d+\b"
 KESP_ID_PATTERN = r"\bK\d+\b"
 RAK_ID_PATTERN = r"([A-Z]{3}\d{4})(-\d{2})?"
+CONSTRUCTIE_PATTERN = r"constructie [a-z]"
 ALGEMEEN_GEBREK_PATTERN = r"^GB\d{1,3}$"
 
 
@@ -154,6 +155,32 @@ def get_rak_id(value: str) -> str | None:
     return match.group(0) if match else None
 
 
+def get_constructienaam(value: str) -> str | None:
+    r"""Extract constructie naam from a string (e.g., 'Constructie A', 'constructie b').
+
+    Parameters
+    ----------
+    value : str
+        Input string that may contain a constructie naam
+
+    Returns
+    -------
+    str | None
+        The extracted constructie naam or None if not found
+    """
+    value = clean_string(value)
+
+    match = re.search(CONSTRUCTIE_PATTERN, value.lower())
+    if match:
+        naam = match.group(0)
+        if len(naam) > 1:
+            naam = naam[0].upper() + naam[1:-1] + naam[-1].upper()
+        else:
+            naam = naam.upper()
+        return naam
+    return None
+
+
 def is_algemeen_gebrek(value: str) -> bool:
     """Check if a string indicates an 'algemeen gebrek'."""
 
@@ -174,6 +201,27 @@ def is_houtmonster_id(value: str) -> bool:
         return False
 
     return True
+
+
+def remove_titel_rows(
+    table_rows: list[list[str]], titel_keywords: list[str] = ["Titel", "Rapportnummer"]
+) -> list[list[str]]:
+    """Remove rows from a table that contain any of the specified titel keywords."""
+
+    return [
+        row
+        for row in table_rows
+        if not any(keyword.lower() in cell.lower() for cell in row for keyword in titel_keywords)
+    ]
+
+
+def remove_invalid_rows(table_rows: list[list[str]]) -> list[list[str]]:
+    if not table_rows:
+        return table_rows
+
+    max_kolommen = max(len(row) for row in table_rows)
+
+    return [row for row in table_rows if len(row) == max_kolommen]
 
 
 def clean_string(value: str) -> str:


### PR DESCRIPTION
fixes #63
fixes #61

This pr does the following:
- Rework of smartdocument to:
1. Be more precise on what sections to target based on the names
2. Return a list[str[str]] with some data cleaning
3. initiate the raknaam from the document instead of path name
