### PR TITLE
70 parsen van palen kespen en houtmonsters verbeteren

### DIFF
--- a/src/tekstherkenning_ark/constants.py
+++ b/src/tekstherkenning_ark/constants.py
@@ -3,8 +3,9 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent.parent.parent
 DATA_DIR = ROOT_DIR / "data"
+DUIKRAPPORTEN_DIR = DATA_DIR / "duikrapporten"
 CACHE_DIR = DATA_DIR / ".cache"
 
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-TEST_PDF_PATH = DATA_DIR / "HEG0801_Houtmonstername&VisueleInspectie_V1.1_20220311.pdf"
+TEST_PDF_PATH = DUIKRAPPORTEN_DIR / "HEG0801_Houtmonstername&VisueleInspectie_V1.1_20220311.pdf"

--- a/src/tekstherkenning_ark/document/rakdeelsectie.py
+++ b/src/tekstherkenning_ark/document/rakdeelsectie.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Literal
 
 from azure.ai.documentintelligence.models import DocumentTable, DocumentParagraph
 
 from tekstherkenning_ark.document.sectie import Sectie
+from tekstherkenning_ark.document.structured_table import StructuredTable
 from tekstherkenning_ark.utils import get_constructienaam, get_table_content, remove_titel_rows, remove_invalid_rows
 
 
@@ -17,16 +19,16 @@ class RakdeelSectie:
         Naam van de constructie.
     beschrijving : list[DocumentParagraph]
         Beschrijvende paragrafen.
-    toestand_tabel : list[list[str]]
-        Tabelinhoud met toestandsinformatie.
-    gebreken_tabel : list[list[str]]
-        Tabelinhoud met gebrekeninformatie.
+    toestand_tabel : StructuredTable | None
+        Structured table met toestandsinformatie.
+    gebreken_tabel : StructuredTable | None
+        Structured table met gebrekeninformatie.
     """
 
     constructie_naam: str
     beschrijving: list[DocumentParagraph]
-    toestand_tabel: list[list[str]]
-    gebreken_tabel: list[list[str]]
+    toestand_tabel: StructuredTable | None
+    gebreken_tabel: StructuredTable | None
 
     @classmethod
     def from_smart_document(cls, secties: list[Sectie]) -> RakdeelSectie:
@@ -49,17 +51,17 @@ class RakdeelSectie:
         """
         constructie_naam = ""
         beschrijving = []
-        toestand_tabel = []
-        gebreken_tabel = []
+        toestand_tabel = None
+        gebreken_tabel = None
 
         for sectie in secties:
             # if sectie titel contains "constructie [a-z]" then it is the base rakdeelsectie
             if get_constructienaam(sectie.titel) and not constructie_naam:
                 constructie_naam = get_constructienaam(sectie.titel) or ""
                 beschrijving = sectie.inhoud
-            elif "toestand" in sectie.titel.lower() and not toestand_tabel:
+            elif "toestand" in sectie.titel.lower() and toestand_tabel is None:
                 toestand_tabel = RakdeelSectie._get_toestand_tabel(sectie.tabellen)
-            elif "gebrek" in sectie.titel.lower() and not gebreken_tabel:
+            elif "gebrek" in sectie.titel.lower() and gebreken_tabel is None:
                 gebreken_tabel = RakdeelSectie._get_gebreken_tabel(sectie.tabellen)
                 break
 
@@ -71,24 +73,20 @@ class RakdeelSectie:
         )
 
     @staticmethod
-    def _get_toestand_tabel(list_of_tables: list[DocumentTable]) -> list[list[str]]:
+    def _get_toestand_tabel(list_of_tables: list[DocumentTable]) -> StructuredTable | None:
         """Helper om de juiste toestand tabel te vinden uit een lijst van tabellen."""
-        rows: list[list[str]] = []
+        if not list_of_tables:
+            return None
 
-        for tabel in list_of_tables:
-            if tabel.cells:
-                rows.extend(get_table_content(tabel))
-        rows_wo_header = remove_titel_rows(rows)
-        rows_cleaned = remove_invalid_rows(rows_wo_header)
-        return rows_cleaned
+        return StructuredTable.from_doc_table(list_of_tables, table_type="toestandsbepaling")
 
     @staticmethod
-    def _get_gebreken_tabel(list_of_tables: list[DocumentTable]) -> list[list[str]]:
+    def _get_gebreken_tabel(list_of_tables: list[DocumentTable]) -> StructuredTable | None:
         """Helper om de juiste gebreken tabel te vinden uit een lijst van tabellen."""
-        rows: list[list[str]] = []
-        for tabel in list_of_tables:
-            if tabel.column_count == 3 and tabel.cells:
-                rows.extend(get_table_content(tabel))
-        rows_wo_header = remove_titel_rows(rows)
-        rows_cleaned = remove_invalid_rows(rows_wo_header)
-        return rows_cleaned
+        # Filter tables with 3 columns (gebreken tables have 3 columns)
+        gebreken_tables = [tabel for tabel in list_of_tables if tabel.column_count == 3 and tabel.cells]
+
+        if not gebreken_tables:
+            return None
+
+        return StructuredTable.from_doc_table(gebreken_tables, table_type="gebreken")

--- a/src/tekstherkenning_ark/document/rakdeelsectie.py
+++ b/src/tekstherkenning_ark/document/rakdeelsectie.py
@@ -5,7 +5,7 @@ from typing import Literal
 from azure.ai.documentintelligence.models import DocumentTable, DocumentParagraph
 
 from tekstherkenning_ark.document.sectie import Sectie
-from tekstherkenning_ark.document.structured_table import StructuredTable
+from tekstherkenning_ark.document.structured_table import StructuredTable, TableType
 from tekstherkenning_ark.utils import get_constructienaam, get_table_content, remove_titel_rows, remove_invalid_rows
 
 
@@ -78,7 +78,7 @@ class RakdeelSectie:
         if not list_of_tables:
             return None
 
-        return StructuredTable.from_doc_table(list_of_tables, table_type="toestandsbepaling")
+        return StructuredTable.from_doc_table(list_of_tables, table_type=TableType.TOESTANDSBEPALING)
 
     @staticmethod
     def _get_gebreken_tabel(list_of_tables: list[DocumentTable]) -> StructuredTable | None:
@@ -89,4 +89,4 @@ class RakdeelSectie:
         if not gebreken_tables:
             return None
 
-        return StructuredTable.from_doc_table(gebreken_tables, table_type="gebreken")
+        return StructuredTable.from_doc_table(gebreken_tables, table_type=TableType.GEBREKEN)

--- a/src/tekstherkenning_ark/document/rakdeelsectie.py
+++ b/src/tekstherkenning_ark/document/rakdeelsectie.py
@@ -6,7 +6,7 @@ from azure.ai.documentintelligence.models import DocumentTable, DocumentParagrap
 
 from tekstherkenning_ark.document.sectie import Sectie
 from tekstherkenning_ark.document.structured_table import StructuredTable, TableType
-from tekstherkenning_ark.utils import get_constructienaam, get_table_content, remove_titel_rows, remove_invalid_rows
+from tekstherkenning_ark.utils import get_constructienaam
 
 
 @dataclass

--- a/src/tekstherkenning_ark/document/smart_document.py
+++ b/src/tekstherkenning_ark/document/smart_document.py
@@ -11,12 +11,7 @@ from tekstherkenning_ark.constants import DATA_DIR
 from tekstherkenning_ark.document.structured_table import StructuredTable
 from tekstherkenning_ark.utils import (
     get_constructienaam,
-    get_paal_id,
-    get_kesp_id,
     get_rak_id,
-    get_table_content,
-    remove_titel_rows,
-    remove_invalid_rows,
 )
 from tekstherkenning_ark.document.sectie import Sectie
 from tekstherkenning_ark.document.rakdeelsectie import RakdeelSectie
@@ -239,41 +234,6 @@ class SmartDocument:
 
             if not assigned and self.sections:
                 self.sections[-1].tabellen.append(table)
-
-    def _is_table_type_by_id_func(
-        self, tabel: DocumentTable, id_func: Callable[[str], str | None], threshold: float = 0.5
-    ) -> bool:
-        """Check of een tabel bij een type hoort op basis van een ID-extractie functie.
-
-        Parameters
-        ----------
-        tabel : DocumentTable
-            De tabel om te controleren.
-        id_func : callable
-            Functie die een string neemt en een ID of None teruggeeft (bijv. get_paal_id).
-        threshold : float
-            Minimale fractie van cellen die moeten matchen.
-
-        Returns
-        -------
-        bool
-            True als de tabel voldoet aan het type.
-        """
-        if not tabel.cells:
-            return False
-
-        first_col_cells = [cell.content for cell in tabel.cells if cell.column_index == 0]
-        if not first_col_cells:
-            return False
-
-        matching_cells = sum(1 for cell in first_col_cells if id_func(cell) is not None)
-        return (matching_cells / len(first_col_cells)) > threshold
-
-    def __repr__(self) -> str:
-        section_summary = "\n".join(
-            [f"  - {s.titel} ({len(s.inhoud)} paragrafen, {len(s.tabellen)} tabellen)" for s in self.sections]
-        )
-        return f"SmartDocument met {len(self.sections)} secties:\n{section_summary}"
 
 
 if __name__ == "__main__":

--- a/src/tekstherkenning_ark/document/smart_document.py
+++ b/src/tekstherkenning_ark/document/smart_document.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 from tekstherkenning_ark import constants
 from tekstherkenning_ark.constants import DATA_DIR
-from tekstherkenning_ark.document.structured_table import StructuredTable
+from tekstherkenning_ark.document.structured_table import StructuredTable, TableType
 from tekstherkenning_ark.utils import (
     get_constructienaam,
     get_rak_id,
@@ -127,7 +127,7 @@ class SmartDocument:
         """
         for sectie in self.sections:
             if "meettabel houtmonsters" in sectie.titel.lower() and sectie.tabellen:
-                return StructuredTable.from_doc_table(sectie.tabellen, table_type="houtmonsters")
+                return StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.HOUTMONSTERS)
 
         return None
 
@@ -142,7 +142,7 @@ class SmartDocument:
         for sectie in self.sections:
             if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
 
-                return StructuredTable.from_doc_table(sectie.tabellen, table_type="palen")
+                return StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.PALEN)
 
         return None
 
@@ -156,7 +156,7 @@ class SmartDocument:
         """
         for sectie in self.sections:
             if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
-                return StructuredTable.from_doc_table(sectie.tabellen, table_type="kespen")
+                return StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.KESPEN)
 
         return None
 

--- a/src/tekstherkenning_ark/document/smart_document.py
+++ b/src/tekstherkenning_ark/document/smart_document.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from tekstherkenning_ark import constants
 from tekstherkenning_ark.constants import DATA_DIR
+from tekstherkenning_ark.document.structured_table import StructuredTable
 from tekstherkenning_ark.utils import (
     get_constructienaam,
     get_paal_id,
@@ -121,67 +122,48 @@ class SmartDocument:
                 rakdeel_secties.append(RakdeelSectie.from_smart_document(self.sections[i:]))
         return rakdeel_secties
 
-    def get_meettabel_houtmonsters(self) -> list[list[str]]:
+    def get_meettabel_houtmonsters(self) -> StructuredTable | None:
         """Haal de meettabel voor houtmonsters op.
 
         Returns
         -------
-        list[list[str]]
-            Tabelinhoud met houtmonster metingen.
+        StructuredTable | None
+            Gestructureerde tabelinhoud met houtmonster metingen.
         """
         for sectie in self.sections:
             if "meettabel houtmonsters" in sectie.titel.lower() and sectie.tabellen:
-                rows: list[list[str]] = []
-                for tabel in sectie.tabellen:
-                    rows.extend(get_table_content(tabel))
-                rows_wo_header = remove_titel_rows(rows)
-                rows_valid = remove_invalid_rows(rows_wo_header)
-                rows_cleaned = [
-                    row for row in rows_valid if all(x not in row[0].lower() for x in ["meettabel", "[rak]"])
-                ]
-                return rows_cleaned
-        return []
+                return StructuredTable.from_doc_table(sectie.tabellen, table_type="houtmonsters")
 
-    def get_meettabel_fundering_paal(self) -> list[list[str]]:
+        return None
+
+    def get_meettabel_fundering_paal(self) -> StructuredTable | None:
         """Haal de meettabel voor palen op.
 
         Returns
         -------
-        list[list[str]]
-            Tabelinhoud waar >50% van eerste kolom een geldig paal ID bevat.
+        StructuredTable | None
+            Gestructureerde tabelinhoud waar >50% van eerste kolom een geldig paal ID bevat.
         """
         for sectie in self.sections:
             if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
-                rows: list[list[str]] = []
-                for tabel in sectie.tabellen:
-                    if self._is_table_type_by_id_func(tabel, get_paal_id):
-                        rows.extend(get_table_content(tabel))
-                rows_wo_header = remove_titel_rows(rows)
-                rows_valid = remove_invalid_rows(rows_wo_header)
-                rows_cleaned = [
-                    row for row in rows_valid if all(x not in row[0].lower() for x in ["meettabel", "[rak]"])
-                ]
-                return rows_cleaned
-        return []
 
-    def get_meettabel_fundering_kesp(self) -> list[list[str]]:
+                return StructuredTable.from_doc_table(sectie.tabellen, table_type="palen")
+
+        return None
+
+    def get_meettabel_fundering_kesp(self) -> StructuredTable | None:
         """Haal de meettabel voor kespen op.
 
         Returns
         -------
-        list[list[str]]
+        StructuredTable | None
             Tabelinhoud waar >50% van eerste kolom een geldig kesp ID bevat.
         """
         for sectie in self.sections:
             if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
-                rows: list[list[str]] = []
-                for tabel in sectie.tabellen:
-                    if self._is_table_type_by_id_func(tabel, get_kesp_id):
-                        rows.extend(get_table_content(tabel))
-                rows_wo_header = remove_titel_rows(rows)
-                rows_cleaned = remove_invalid_rows(rows_wo_header)
-                return rows_cleaned
-        return []
+                return StructuredTable.from_doc_table(sectie.tabellen, table_type="kespen")
+
+        return None
 
     def get_raknaam(self) -> str:
         for tabel in self.sections[0].tabellen:

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import cached_property
+import math
 from typing import Literal
 from azure.ai.documentintelligence.models import DocumentTable
 
@@ -27,34 +28,81 @@ class TableType(StrEnum):
     TOESTANDSBEPALING = "toestandsbepaling"
 
     @cached_property
-    def header_offset(self) -> int:
-        """Houtmonsters have their header on the second row, rest is first row."""
-
-        if self is self.HOUTMONSTERS:
-            return 1
-        return 0
-
-    @cached_property
-    def sub_header_offset(self) -> int | None:
+    def has_sub_header(self) -> bool:
         """Only palen and kespen have a sub-header row."""
 
-        if self in [self.PALEN, self.KESPEN]:
-            return 1
-        return None
+        return self in [self.PALEN, self.KESPEN]
 
     @cached_property
-    def unit_offset(self) -> int | None:
+    def has_unit(self) -> bool:
         """Only palen, kespen and houtmonsters have a unit row."""
 
-        if self in [self.PALEN, self.KESPEN, self.HOUTMONSTERS]:
-            return 2
-        return None
+        return self in [self.PALEN, self.KESPEN, self.HOUTMONSTERS]
+
+    @cached_property
+    def unit_offset(self) -> int:
+        """Return the expected row index for the unit row based on the table type."""
+
+        return int(self.has_sub_header) + int(self.has_unit)
 
     @cached_property
     def values_offset(self) -> int:
         """Calculate the offset for the first row of values based on the presence of header, sub-header and unit rows."""
 
-        return max(self.header_offset, self.sub_header_offset or 0, self.unit_offset or 0) + 1
+        return self.unit_offset + 1
+
+    @cached_property
+    def expected_header_colnames(self) -> list[str]:
+        """Return expected header column names for this table type in lowercase for case-insensitive matching."""
+
+        if self is self.PALEN:
+            return [
+                "paalnummer",
+                "diameter",
+                "hart-op-hart-afstanden",
+                "schoorstand",
+                "afstand",
+                "schades",
+                "aansluiting",
+                "opmerkingen",
+                "onderzocht",
+            ]
+        elif self is self.KESPEN:
+            return [
+                "kespnummer",
+                "afmetingen",
+                "hoek t.o.v. lengte-as frontwand",
+                "lengte uitstekende deel t.o.v. voorzijde frontwand",
+                "mate van inknijping",
+                "indrukking van de funderingspaal in de kesp",
+                "opsluitklos",
+                "schades",
+            ]
+        elif self is self.HOUTMONSTERS:
+            return [
+                "codering",
+                "rakcode",
+                "paalnummer",
+                "houtmonster",
+                "diameter paal",
+                "hoogte t.o.v. nap",
+                "hoogte t.o.v. kesp/vloer",
+                "wankant aanwezig?",
+                "datum monstername",
+            ]
+        elif self is self.GEBREKEN:
+            return [
+                "gebrekcodering",
+                "omschrijving",
+                "figuurnummer",
+            ]
+        elif self is self.TOESTANDSBEPALING:
+            return [
+                "constructieonderdeel",
+                "aangetast",
+            ]
+        else:
+            raise NotImplementedError(f"Expected header column names not defined for table type: {self}")
 
 
 @dataclass(frozen=True)
@@ -113,7 +161,9 @@ class StructuredTable:
             if id_func is None or is_table_type_by_id_func(tabel, id_func):
                 rows.extend(get_table_content(tabel))
         rows_wo_header = remove_titel_rows(rows)
-        table_rows = remove_invalid_rows(rows_wo_header)
+        valid_table_rows = remove_invalid_rows(rows_wo_header)
+
+        table_rows = cls.remove_rows_before_header(valid_table_rows, table_type)
 
         # If there is no data or there are no value rows, return an empty StructuredTable
         if len(table_rows) <= table_type.values_offset:
@@ -218,6 +268,33 @@ class StructuredTable:
         self.col_lookup_cache[cache_key] = None
         return None
 
+    @staticmethod
+    def is_header_row(row: list[str], table_type: TableType, threshold: float = 0.5) -> bool:
+        """Return whether the current row is likely to be a header row or not"""
+
+        row_clean = [clean_string(val).lower() for val in row]
+        row_values = [val for val in row_clean if val]
+
+        present_count = sum(val in table_type.expected_header_colnames for val in row_values)
+        required_count = int(math.ceil(len(row_values) * threshold))
+        return present_count >= required_count
+
+    @classmethod
+    def remove_rows_before_header(cls, table_rows: list[list[str]], table_type: TableType) -> list[list[str]]:
+        """Remove rows before the header row based on the expected header column names for the given table type."""
+
+        # Get the header row location
+        first_header_row_index = next(
+            (index for index, row in enumerate(table_rows) if cls.is_header_row(row, table_type)), None
+        )
+
+        # Return the table rows starting from the header row (inclusive) or the original rows if no header row is found
+        if first_header_row_index is not None:
+            return table_rows[first_header_row_index:]
+
+        logger.warning(f"No header row found for table type {table_type}. Returning original rows.")
+        return table_rows
+
 
 @dataclass
 class TableColumn:
@@ -254,16 +331,16 @@ class TableColumn:
         last_unit_value = ""
 
         for col in columns:
-            if col[table_type.header_offset]:
-                last_header_value = col[table_type.header_offset]
+            if col[0]:
+                last_header_value = col[0]
                 last_sub_header_value = ""
                 last_unit_value = ""
 
-            if table_type.sub_header_offset is not None and col[table_type.sub_header_offset]:
-                last_sub_header_value = col[table_type.sub_header_offset]
+            if table_type.has_sub_header and col[1]:
+                last_sub_header_value = col[1]
                 last_unit_value = ""
 
-            if table_type.unit_offset is not None and col[table_type.unit_offset]:
+            if table_type.has_unit and col[table_type.unit_offset]:
                 last_unit_value = col[table_type.unit_offset]
 
             values = list(col[table_type.values_offset :])

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
-from functools import cache, cached_property
-from typing import Any, Literal
+from typing import Literal
 from azure.ai.documentintelligence.models import DocumentTable
 
-from tekstherkenning_ark.document import sectie
 from tekstherkenning_ark.logger import get_logger
 from tekstherkenning_ark.utils import (
     clean_string,
@@ -174,15 +172,6 @@ class StructuredTable:
         )
         self.col_lookup_cache[cache_key] = None
         return None
-
-    @cached_property
-    def hash(self) -> str:
-        """Generate a hash for the structured table based on its content. This can be used for caching or comparison purposes."""
-        column_hashes = [f"{col.header}|{col.sub_header}|{col.unit}|{'|'.join(col.values)}" for col in self.columns]
-        return hash("|".join(column_hashes))
-
-    def __hash__(self):
-        return self.hash
 
 
 @dataclass

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -7,6 +7,7 @@ from azure.ai.documentintelligence.models import DocumentTable
 from tekstherkenning_ark.document import sectie
 from tekstherkenning_ark.logger import get_logger
 from tekstherkenning_ark.utils import (
+    clean_string,
     get_kesp_id,
     get_paal_id,
     get_table_content,
@@ -94,7 +95,7 @@ class StructuredTable:
 
         column = self.get_column(header_in, sub_header_in, unit_in)
         if not column is None and column.values:
-            return column.values[index]
+            return clean_string(column.values[index])
 
         return None
 

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cache, cached_property
-from typing import Literal
+from typing import Any, Literal
 from azure.ai.documentintelligence.models import DocumentTable
 
 from tekstherkenning_ark.document import sectie
@@ -28,6 +28,8 @@ class StructuredTable:
 
     columns: list[TableColumn]
     table_type: Literal["palen", "kespen", "houtmonsters"]
+
+    col_lookup_cache: dict[tuple, TableColumn] = field(default_factory=dict, init=False, repr=False)
 
     @property
     def num_rows(self) -> int:
@@ -83,9 +85,9 @@ class StructuredTable:
 
     def get_value(
         self,
-        header_in: str | list[str] = None,
-        sub_header_in: str | list[str] = None,
-        unit_in: str | list[str] = None,
+        header_in: str | list[str] = "",
+        sub_header_in: str | list[str] = "",
+        unit_in: str | list[str] = "",
         index: int = 0,
     ) -> str | None:
         """Get a value from the structured table based on header, sub-header, unit and row index by matching against possible values. Matching is case-insensitive."""
@@ -96,7 +98,6 @@ class StructuredTable:
 
         return None
 
-    @cache
     def get_column(
         self,
         header_in: str | list[str] = "",
@@ -131,6 +132,11 @@ class StructuredTable:
         if isinstance(unit_in, str):
             unit_in = [unit_in]
 
+        # Check cache first (for performance reasons)
+        cache_key = (tuple(header_in), tuple(sub_header_in), tuple(unit_in))
+        if cache_key in self.col_lookup_cache:
+            return self.col_lookup_cache[cache_key]
+
         # Make everything lowercase for case-insensitive matching
         header_in = [h.lower() for h in header_in] if header_in else None
         sub_header_in = [sh.lower() for sh in sub_header_in] if sub_header_in else None
@@ -144,12 +150,14 @@ class StructuredTable:
 
         # If exactly one column matches based on header and sub-header, return it.
         if len(subheader_matching_columns) == 1:
+            self.col_lookup_cache[cache_key] = subheader_matching_columns[0]
             return subheader_matching_columns[0]
 
         # If multiple columns match based on header and sub-header, use unit to disambiguate if possible.
         elif len(subheader_matching_columns) > 1 and unit_in is not None:
             for column in subheader_matching_columns:
                 if column.unit.lower() in unit_in:
+                    self.col_lookup_cache[cache_key] = column
                     return column
 
         # No matching columns, warn
@@ -163,6 +171,7 @@ class StructuredTable:
         logger.warning(
             f"No matching column found for {self.table_type} table for arguments {header_in}, {sub_header_in}, {unit_in}. {available_subheaders_str}Returning None."
         )
+        self.col_lookup_cache[cache_key] = None
         return None
 
     @cached_property
@@ -200,6 +209,7 @@ class TableColumn:
         """
 
         sub_header_col_offset = int(has_sub_header)
+        header_i = int(not has_sub_header)  # 0 if we have a sub-header, 1 if we don't
 
         # Create TableColumn objects for each column
         table_columns = []
@@ -208,8 +218,8 @@ class TableColumn:
         last_unit_value = ""
 
         for col in columns:
-            if col[0]:
-                last_header_value = col[0]
+            if col[header_i]:
+                last_header_value = col[header_i]
                 last_sub_header_value = ""
                 last_unit_value = ""
 

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
+from enum import StrEnum
+from functools import cached_property
 from typing import Literal
 from azure.ai.documentintelligence.models import DocumentTable
 
@@ -17,6 +19,44 @@ from tekstherkenning_ark.utils import (
 logger = get_logger(__name__)
 
 
+class TableType(StrEnum):
+    PALEN = "palen"
+    KESPEN = "kespen"
+    HOUTMONSTERS = "houtmonsters"
+    GEBREKEN = "gebreken"
+    TOESTANDSBEPALING = "toestandsbepaling"
+
+    @cached_property
+    def header_offset(self) -> int:
+        """Houtmonsters have their header on the second row, rest is first row."""
+
+        if self is self.HOUTMONSTERS:
+            return 1
+        return 0
+
+    @cached_property
+    def sub_header_offset(self) -> int | None:
+        """Only palen and kespen have a sub-header row."""
+
+        if self in [self.PALEN, self.KESPEN]:
+            return 1
+        return None
+
+    @cached_property
+    def unit_offset(self) -> int | None:
+        """Only palen, kespen and houtmonsters have a unit row."""
+
+        if self in [self.PALEN, self.KESPEN, self.HOUTMONSTERS]:
+            return 2
+        return None
+
+    @cached_property
+    def values_offset(self) -> int:
+        """Calculate the offset for the first row of values based on the presence of header, sub-header and unit rows."""
+
+        return max(self.header_offset, self.sub_header_offset or 0, self.unit_offset or 0) + 1
+
+
 @dataclass(frozen=True)
 class StructuredTable:
     """A structured representation of a table extracted from a document, with methods to access its values based on headers, sub-headers and units.
@@ -26,7 +66,7 @@ class StructuredTable:
     Some functions are cached for performance reasons thus the underlying data should be immutable to avoid issues."""
 
     columns: list[TableColumn]
-    table_type: Literal["palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling"]
+    table_type: TableType
 
     col_lookup_cache: dict[tuple, TableColumn] = field(default_factory=dict, init=False, repr=False)
 
@@ -38,14 +78,17 @@ class StructuredTable:
     def from_doc_table(
         cls,
         tables: list[DocumentTable],
-        table_type: Literal["palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling"],
+        table_type: TableType,
     ) -> StructuredTable:
         """Parse and return a StructuredTable object from table rows.
 
         Parameters
         ----------
-        table_rows : list[list[str]]
-            List of table rows as lists of strings.
+        tables: list[DocumentTable]
+            List of DocumentTable objects to parse and find the relevant table based on the table type.
+        table_type: TableType
+            The type of the table to parse, which determines how headers, sub-headers and units are identified and how the values are extracted.
+            Possible values: "palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling".
 
         Returns
         -------
@@ -53,20 +96,16 @@ class StructuredTable:
             A StructuredTable object containing information from the table with headers, sub-headers, units, and values.
         """
 
-        # Validate table type
-        if not table_type in ["palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling"]:
-            raise ValueError(
-                f"Invalid table type: {table_type}. Must be one of: palen, kespen, houtmonsters, gebreken, toestandsbepaling"
-            )
+        # Ensure table_type is a valid TableType enum member
+        table_type = TableType(table_type)
 
+        # Define a mapping of table types to their corresponding ID extraction functions (if applicable)
         id_func_dict = {
-            "palen": get_paal_id,
-            "kespen": get_kesp_id,
-            "houtmonsters": None,
-            "gebreken": None,
-            "toestandsbepaling": None,
+            TableType.PALEN: get_paal_id,
+            TableType.KESPEN: get_kesp_id,
         }
-        id_func = id_func_dict[table_type]
+
+        id_func = id_func_dict.get(table_type, None)
 
         # Extract rows from all tables
         rows: list[list[str]] = []
@@ -76,19 +115,15 @@ class StructuredTable:
         rows_wo_header = remove_titel_rows(rows)
         table_rows = remove_invalid_rows(rows_wo_header)
 
-        # Determine if the table has a sub-header row based on the table type
-        has_sub_header = table_type in ["palen", "kespen"]
-        sub_header_col_offset = int(has_sub_header)
-
         # If there is no data or there are no value rows, return an empty StructuredTable
-        if len(table_rows) <= (2 + sub_header_col_offset):
+        if len(table_rows) <= table_type.values_offset:
             return StructuredTable(columns=[], table_type=table_type)
 
         # Transpose rows to columns
         columns = list(zip(*table_rows))
 
         # Create TableColumn objects for each column
-        table_columns = TableColumn.from_column_lists(columns, has_sub_header=has_sub_header)
+        table_columns = TableColumn.from_column_lists(columns, table_type)
 
         return StructuredTable(columns=table_columns, table_type=table_type)
 
@@ -192,7 +227,11 @@ class TableColumn:
     values: list[str] = None
 
     @classmethod
-    def from_column_lists(cls, columns: list[list[str]], has_sub_header: bool) -> list[TableColumn]:
+    def from_column_lists(
+        cls,
+        columns: list[list[str]],
+        table_type: TableType,
+    ) -> list[TableColumn]:
         """Create TableColumn objects from lists of column values, determining headers, sub-headers and units based on the table type.
 
         Parameters
@@ -208,9 +247,6 @@ class TableColumn:
             A list of TableColumn objects containing header, sub-header, unit and values for each column.
         """
 
-        sub_header_col_offset = int(has_sub_header)
-        header_i = int(not has_sub_header)  # 0 if we have a sub-header, 1 if we don't
-
         # Create TableColumn objects for each column
         table_columns = []
         last_header_value = ""
@@ -218,17 +254,19 @@ class TableColumn:
         last_unit_value = ""
 
         for col in columns:
-            if col[header_i]:
-                last_header_value = col[header_i]
+            if col[table_type.header_offset]:
+                last_header_value = col[table_type.header_offset]
                 last_sub_header_value = ""
                 last_unit_value = ""
 
-            if has_sub_header and col[1]:
-                last_sub_header_value = col[1]
+            if table_type.sub_header_offset is not None and col[table_type.sub_header_offset]:
+                last_sub_header_value = col[table_type.sub_header_offset]
                 last_unit_value = ""
 
-            last_unit_value = col[1 + sub_header_col_offset] or last_unit_value
-            values = list(col[2 + sub_header_col_offset :])
+            if table_type.unit_offset is not None and col[table_type.unit_offset]:
+                last_unit_value = col[table_type.unit_offset]
+
+            values = list(col[table_type.values_offset :])
 
             table_columns.append(cls(last_header_value, last_sub_header_value, last_unit_value, values))
 

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -20,13 +20,13 @@ logger = get_logger(__name__)
 @dataclass(frozen=True)
 class StructuredTable:
     """A structured representation of a table extracted from a document, with methods to access its values based on headers, sub-headers and units.
-    Used for parsing the palen, kespen and houtmonsters tables in the rakdeel secties.
+    Used for parsing the palen, kespen, houtmonsters, gebreken and toestandsbepaling tables in the rakdeel secties.
 
     The dataclass is frozen, meaning the structured table should not be modified after creation.
     Some functions are cached for performance reasons thus the underlying data should be immutable to avoid issues."""
 
     columns: list[TableColumn]
-    table_type: Literal["palen", "kespen", "houtmonsters"]
+    table_type: Literal["palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling"]
 
     col_lookup_cache: dict[tuple, TableColumn] = field(default_factory=dict, init=False, repr=False)
 
@@ -36,7 +36,9 @@ class StructuredTable:
 
     @classmethod
     def from_doc_table(
-        cls, tables: list[DocumentTable], table_type: Literal["palen", "kespen", "houtmonsters"]
+        cls,
+        tables: list[DocumentTable],
+        table_type: Literal["palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling"],
     ) -> StructuredTable:
         """Parse and return a StructuredTable object from table rows.
 
@@ -52,10 +54,18 @@ class StructuredTable:
         """
 
         # Validate table type
-        if not table_type in ["palen", "kespen", "houtmonsters"]:
-            raise ValueError(f"Invalid table type: {table_type}. Expected 'palen', 'kespen' or 'houtmonsters'.")
+        if not table_type in ["palen", "kespen", "houtmonsters", "gebreken", "toestandsbepaling"]:
+            raise ValueError(
+                f"Invalid table type: {table_type}. Must be one of: palen, kespen, houtmonsters, gebreken, toestandsbepaling"
+            )
 
-        id_func_dict = {"palen": get_paal_id, "kespen": get_kesp_id, "houtmonsters": None}
+        id_func_dict = {
+            "palen": get_paal_id,
+            "kespen": get_kesp_id,
+            "houtmonsters": None,
+            "gebreken": None,
+            "toestandsbepaling": None,
+        }
         id_func = id_func_dict[table_type]
 
         # Extract rows from all tables

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from functools import cache, cached_property
+from typing import Literal
+from azure.ai.documentintelligence.models import DocumentTable
+
+from tekstherkenning_ark.document import sectie
+from tekstherkenning_ark.logger import get_logger
+from tekstherkenning_ark.utils import (
+    get_kesp_id,
+    get_paal_id,
+    get_table_content,
+    is_table_type_by_id_func,
+    remove_invalid_rows,
+    remove_titel_rows,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class StructuredTable:
+    """A structured representation of a table extracted from a document, with methods to access its values based on headers, sub-headers and units.
+    Used for parsing the palen, kespen and houtmonsters tables in the rakdeel secties.
+
+    The dataclass is frozen, meaning the structured table should not be modified after creation.
+    Some functions are cached for performance reasons thus the underlying data should be immutable to avoid issues."""
+
+    columns: list[TableColumn]
+    table_type: Literal["palen", "kespen", "houtmonsters"]
+
+    @property
+    def num_rows(self) -> int:
+        return len(self.columns[0].values) if self.columns else 0
+
+    @classmethod
+    def from_doc_table(
+        cls, tables: list[DocumentTable], table_type: Literal["palen", "kespen", "houtmonsters"]
+    ) -> StructuredTable:
+        """Parse and return a StructuredTable object from table rows.
+
+        Parameters
+        ----------
+        table_rows : list[list[str]]
+            List of table rows as lists of strings.
+
+        Returns
+        -------
+        StructuredTable
+            A StructuredTable object containing information from the table with headers, sub-headers, units, and values.
+        """
+
+        # Validate table type
+        if not table_type in ["palen", "kespen", "houtmonsters"]:
+            raise ValueError(f"Invalid table type: {table_type}. Expected 'palen', 'kespen' or 'houtmonsters'.")
+
+        id_func_dict = {"palen": get_paal_id, "kespen": get_kesp_id, "houtmonsters": None}
+        id_func = id_func_dict[table_type]
+
+        # Extract rows from all tables
+        rows: list[list[str]] = []
+        for tabel in tables:
+            if id_func is None or is_table_type_by_id_func(tabel, id_func):
+                rows.extend(get_table_content(tabel))
+        rows_wo_header = remove_titel_rows(rows)
+        table_rows = remove_invalid_rows(rows_wo_header)
+
+        # Determine if the table has a sub-header row based on the table type
+        has_sub_header = table_type in ["palen", "kespen"]
+        sub_header_col_offset = int(has_sub_header)
+
+        # If there is no data or there are no value rows, return an empty StructuredTable
+        if len(table_rows) <= (2 + sub_header_col_offset):
+            return StructuredTable(columns=[], table_type=table_type)
+
+        # Transpose rows to columns
+        columns = list(zip(*table_rows))
+
+        # Create TableColumn objects for each column
+        table_columns = TableColumn.from_column_lists(columns, has_sub_header=has_sub_header)
+
+        return StructuredTable(columns=table_columns, table_type=table_type)
+
+    def get_value(
+        self,
+        header_in: str | list[str] = None,
+        sub_header_in: str | list[str] = None,
+        unit_in: str | list[str] = None,
+        index: int = 0,
+    ) -> str | None:
+        """Get a value from the structured table based on header, sub-header, unit and row index by matching against possible values. Matching is case-insensitive."""
+
+        column = self.get_column(header_in, sub_header_in, unit_in)
+        if not column is None and column.values:
+            return column.values[index]
+
+        return None
+
+    @cache
+    def get_column(
+        self,
+        header_in: str | list[str] = "",
+        sub_header_in: str | list[str] = "",
+        unit_in: str | list[str] = "",
+    ) -> TableColumn | None:
+        """Get a column from the structured table based on header, sub-header and unit by matching against possible values.
+        Matching is case-insensitive.
+
+        Unit is only considered if there are multiple matches based on header and sub-header.
+
+        Parameters
+        ----------
+        header_in : str | list[str], optional
+            List of possible header values to match. If not provided the header is ignored.
+        sub_header_in : str | list[str], optional
+            List of possible sub-header values to match. If not provided the sub-header is ignored.
+        unit_in : str | list[str], optional
+            List of possible unit values to match. If not provided the unit is ignored.
+
+        Returns
+        -------
+        TableColumn | None
+            The matching TableColumn object or None if no match is found.
+        """
+
+        # Convert single string inputs to lists for uniform processing
+        if isinstance(header_in, str):
+            header_in = [header_in]
+        if isinstance(sub_header_in, str):
+            sub_header_in = [sub_header_in]
+        if isinstance(unit_in, str):
+            unit_in = [unit_in]
+
+        # Make everything lowercase for case-insensitive matching
+        header_in = [h.lower() for h in header_in] if header_in else None
+        sub_header_in = [sh.lower() for sh in sub_header_in] if sub_header_in else None
+        unit_in = [u.lower() for u in unit_in] if unit_in else None
+
+        # Determine columns that match header and sub-header criteria
+        header_matching_columns = [c for c in self.columns if not header_in or c.header.lower() in header_in]
+        subheader_matching_columns = [
+            c for c in header_matching_columns if not sub_header_in or c.sub_header.lower() in sub_header_in
+        ]
+
+        # If exactly one column matches based on header and sub-header, return it.
+        if len(subheader_matching_columns) == 1:
+            return subheader_matching_columns[0]
+
+        # If multiple columns match based on header and sub-header, use unit to disambiguate if possible.
+        elif len(subheader_matching_columns) > 1 and unit_in is not None:
+            for column in subheader_matching_columns:
+                if column.unit.lower() in unit_in:
+                    return column
+
+        # No matching columns, warn
+        available_subheaders_str = ""
+        if header_matching_columns:
+            available_subheaders = sorted([c.sub_header for c in header_matching_columns if c.sub_header])
+            if available_subheaders:
+                available_subheaders_str = (
+                    "Available sub-headers within header: " + ", ".join(available_subheaders) + ". "
+                )
+        logger.warning(
+            f"No matching column found for {self.table_type} table for arguments {header_in}, {sub_header_in}, {unit_in}. {available_subheaders_str}Returning None."
+        )
+        return None
+
+    @cached_property
+    def hash(self) -> str:
+        """Generate a hash for the structured table based on its content. This can be used for caching or comparison purposes."""
+        column_hashes = [f"{col.header}|{col.sub_header}|{col.unit}|{'|'.join(col.values)}" for col in self.columns]
+        return hash("|".join(column_hashes))
+
+    def __hash__(self):
+        return self.hash
+
+
+@dataclass
+class TableColumn:
+    header: str
+    sub_header: str = ""
+    unit: str = ""
+    values: list[str] = None
+
+    @classmethod
+    def from_column_lists(cls, columns: list[list[str]], has_sub_header: bool) -> list[TableColumn]:
+        """Create TableColumn objects from lists of column values, determining headers, sub-headers and units based on the table type.
+
+        Parameters
+        ----------
+        columns : list[list[str]]
+            List of columns as lists of strings, where the first few rows may contain headers, sub-headers and units.
+        has_sub_header : bool
+            Indicates whether the table has a sub-header row (e.g. for palen and kespen tables).
+
+        Returns
+        -------
+        list[TableColumn]
+            A list of TableColumn objects containing header, sub-header, unit and values for each column.
+        """
+
+        sub_header_col_offset = int(has_sub_header)
+
+        # Create TableColumn objects for each column
+        table_columns = []
+        last_header_value = ""
+        last_sub_header_value = ""
+        last_unit_value = ""
+
+        for col in columns:
+            if col[0]:
+                last_header_value = col[0]
+                last_sub_header_value = ""
+                last_unit_value = ""
+
+            if has_sub_header and col[1]:
+                last_sub_header_value = col[1]
+                last_unit_value = ""
+
+            last_unit_value = col[1 + sub_header_col_offset] or last_unit_value
+            values = list(col[2 + sub_header_col_offset :])
+
+            table_columns.append(cls(last_header_value, last_sub_header_value, last_unit_value, values))
+
+        return table_columns

--- a/src/tekstherkenning_ark/logger.py
+++ b/src/tekstherkenning_ark/logger.py
@@ -75,29 +75,9 @@ def get_logger(name: str) -> logging.Logger:
     # Ensure root logger is configured for exception handling
     _ensure_root_logger_configured()
 
+    # Return a logger that will use the root logger's handlers via propagation
     logger = logging.getLogger(name)
-
-    # Only configure if not already configured
-    if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
-
-        # File handler - DEBUG level and above
-        file_handler = RotatingFileHandler(
-            LOG_FILE, maxBytes=10 * 1024 * 1024, backupCount=5, encoding="utf-8"  # 10 MB
-        )
-        file_handler.setLevel(logging.DEBUG)
-        file_formatter = logging.Formatter(LOG_FORMAT, DATE_FORMAT)
-        file_handler.setFormatter(file_formatter)
-
-        # Console handler - INFO level and above
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setLevel(logging.INFO)
-        console_formatter = logging.Formatter(LOG_FORMAT, DATE_FORMAT)
-        console_handler.setFormatter(console_formatter)
-
-        # Add handlers
-        logger.addHandler(file_handler)
-        logger.addHandler(console_handler)
+    logger.setLevel(logging.DEBUG)
 
     return logger
 

--- a/src/tekstherkenning_ark/models/gebrek.py
+++ b/src/tekstherkenning_ark/models/gebrek.py
@@ -11,6 +11,7 @@ from tekstherkenning_ark.utils import (
     is_algemeen_gebrek,
 )
 from tekstherkenning_ark.enums import NietBeschikbaar
+from tekstherkenning_ark.document.structured_table import StructuredTable
 from tekstherkenning_ark.llm.gebrek_classificatie import (
     ScheurMetselwerkLLM,
     ScheurHoutLLM,
@@ -42,37 +43,48 @@ class Gebrek(BaseModel):
     figuurnummer: str | NietBeschikbaar
 
     @classmethod
-    async def from_doc_tables(cls, rows: list[list[str]]) -> list[Gebrek]:
-        """Maak een lijst van Gebrek instanties uit tabel rijen.
+    async def from_doc_tables(cls, structured_table: StructuredTable | None) -> list[Gebrek]:
+        """Maak een lijst van Gebrek instanties uit een structured table.
 
         Parameters
         ----------
-        rows : list[list[str]]
-            Lijst van tabel rijen als lijsten van strings.
+        structured_table : StructuredTable | None
+            Structured table met gebrek informatie.
 
         Returns
         -------
         list[Gebrek]
             Een lijst van Gebrek instanties.
         """
-        expected_header = ["Gebrekcodering", "Omschrijving", "Figuurnummer"]
-
-        # Check header and filter content rows
-        if rows and rows[0] != expected_header:
-            logger.warning(
-                f"Onverwachte tabel header. Verwacht {expected_header}, kreeg {rows[0] if rows else 'leeg'}..."
-            )
+        if structured_table is None:
+            logger.warning("Geen gebreken tabel gevonden")
             return []
 
-        # Skip header row
-        gebrek_rows = [r for r in rows if r[0] != expected_header[0]]
+        # Get columns
+        codering_col = structured_table.get_column(header_in="Gebrekcodering")
+        omschrijving_col = structured_table.get_column(header_in="Omschrijving")
+        figuurnummer_col = structured_table.get_column(header_in="Figuurnummer")
+
+        if not codering_col or not omschrijving_col or not figuurnummer_col:
+            logger.error("Could not find required columns in gebreken table")
+            return []
 
         # Parsing logica om Gebrek instanties te maken
         list_gebreken = []
-        for row in gebrek_rows:
-            if row[0].strip() == "-" or row[0].strip() == "":
+        num_rows = len(codering_col.values)
+
+        for row_idx in range(num_rows):
+            codering_val = codering_col.values[row_idx].strip()
+
+            # Stop at empty or dash rows
+            if codering_val == "-" or codering_val == "":
                 break
-            gebrek_instance = cls(codering=row[0], omschrijving=row[1], figuurnummer=row[2])
+
+            gebrek_instance = cls(
+                codering=codering_val,
+                omschrijving=omschrijving_col.values[row_idx],
+                figuurnummer=figuurnummer_col.values[row_idx],
+            )
             list_gebreken.append(gebrek_instance)
 
         # Classificeer elk gebrek naar een specifiek subtype indien mogelijk (parallel)

--- a/src/tekstherkenning_ark/models/houtmonster.py
+++ b/src/tekstherkenning_ark/models/houtmonster.py
@@ -115,9 +115,13 @@ class Houtmonster(RakBaseModel):
             rak_code=table.get_value(header_in="Rakcode", unit_in="[RAKxxxx]", index=row_idx),
             paal_nummer=table.get_value(header_in="Paalnummer", unit_in="[Px.y]", index=row_idx),
             houtmonster_code=table.get_value(header_in="Houtmonster", unit_in="[HMxxxxx]", index=row_idx),
-            diameter_paal_ter_hoogte_houtmonster_mm=table.get_value(header_in="Diameter paal", unit_in="[mm]", index=row_idx),
+            diameter_paal_ter_hoogte_houtmonster_mm=table.get_value(
+                header_in="Diameter paal", unit_in="[mm]", index=row_idx
+            ),
             hoogte_onder_nap_cm=table.get_value(header_in="Hoogte t.o.v. NAP", unit_in="[cm]", index=row_idx),
-            hoogte_tov_onderzijde_fundering_cm=table.get_value(header_in="Hoogte t.o.v. kesp/vloer", unit_in="[cm]", index=row_idx),
+            hoogte_tov_onderzijde_fundering_cm=table.get_value(
+                header_in="Hoogte t.o.v. kesp/vloer", unit_in="[cm]", index=row_idx
+            ),
             is_wankant_aanwezig=utils.parse_ja_nee(wankant_val) if wankant_val else None,
             datum_monstername=table.get_value(header_in="Datum monstername", unit_in="[dd-mm-j\\]", index=row_idx),
         )

--- a/src/tekstherkenning_ark/models/houtmonster.py
+++ b/src/tekstherkenning_ark/models/houtmonster.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from tekstherkenning_ark import utils
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
+from tekstherkenning_ark.document.structured_table import StructuredTable
+from tekstherkenning_ark.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class Houtmonster(RakBaseModel):
@@ -52,13 +56,13 @@ class Houtmonster(RakBaseModel):
         return str(self.codering)
 
     @classmethod
-    def from_doc_tables(cls, rows: list[list[str]]) -> list[Houtmonster]:
-        """Parse and return a list of Houtmonster objects from table rows.
+    def from_doc_tables(cls, structured_table: StructuredTable) -> list[Houtmonster]:
+        """Parse and return a list of Houtmonster objects from a structured table.
 
         Parameters
         ----------
-        rows : list[list[str]]
-            List of table rows as lists of strings.
+        structured_table : StructuredTable
+            Structured table containing houtmonster data with expected headers.
 
         Returns
         -------
@@ -66,23 +70,37 @@ class Houtmonster(RakBaseModel):
             A list of Houtmonster objects containing information from the table.
         """
 
-        # Skip header rows and filter to houtmonster rows
-        houtmonster_rows = [r for r in rows if utils.is_houtmonster_id(r[0])]
+        # Get the codering column to identify valid houtmonster rows
+        codering_col = structured_table.get_column(header_in="Codering", unit_in="[RAKxxxx/Px.y/HM]")
+
+        if not codering_col:
+            logger.error("Could not find codering column in table")
+            return []
 
         # Parse each row into a Houtmonster object
-        houtmonster_list = [cls.from_houtmonster_table_row(row) for row in houtmonster_rows]
+        houtmonster_list = []
+        num_rows = len(codering_col.values)
+
+        for row_idx in range(num_rows):
+            codering_val = codering_col.values[row_idx]
+
+            if utils.is_houtmonster_id(codering_val):
+                houtmonster = cls.from_houtmonster_table_row(structured_table, row_idx)
+                houtmonster_list.append(houtmonster)
 
         return houtmonster_list
 
     @classmethod
-    def from_houtmonster_table_row(cls, row: list[str]) -> Houtmonster:
+    def from_houtmonster_table_row(cls, table: StructuredTable, row_idx: int) -> Houtmonster:
         """Parse and return a Houtmonster object from a single row of the
-        houtmonsteren table.
+        houtmonsteren structured table.
 
         Parameters
         ----------
-        row : list[str]
-            A single row from the houtmonsteren table as a list of strings.
+        table : StructuredTable
+            Structured table containing houtmonster data.
+        row_idx : int
+            Index of the row to parse.
 
         Returns
         -------
@@ -90,18 +108,18 @@ class Houtmonster(RakBaseModel):
             A Houtmonster object containing information from the row.
         """
 
-        row_clean = [utils.clean_string(val) for val in row]
+        wankant_val = table.get_value(header_in="Wankant aanwezig?", unit_in="[Ja/Nee]", index=row_idx)
 
         return cls(
-            codering=row_clean[0],
-            rak_code=row_clean[1],
-            paal_nummer=row_clean[2],
-            houtmonster_code=row_clean[3],
-            diameter_paal_ter_hoogte_houtmonster_mm=row_clean[4],
-            hoogte_onder_nap_cm=row_clean[5],
-            hoogte_tov_onderzijde_fundering_cm=row_clean[6],
-            is_wankant_aanwezig=utils.parse_ja_nee(row_clean[7]) if row_clean[7] else None,
-            datum_monstername=row_clean[8],
+            codering=table.get_value(header_in="Codering", unit_in="[RAKxxxx/Px.y/HM]", index=row_idx),
+            rak_code=table.get_value(header_in="Rakcode", unit_in="[RAKxxxx]", index=row_idx),
+            paal_nummer=table.get_value(header_in="Paalnummer", unit_in="[Px.y]", index=row_idx),
+            houtmonster_code=table.get_value(header_in="Houtmonster", unit_in="[HMxxxxx]", index=row_idx),
+            diameter_paal_ter_hoogte_houtmonster_mm=table.get_value(header_in="Diameter paal", unit_in="[mm]", index=row_idx),
+            hoogte_onder_nap_cm=table.get_value(header_in="Hoogte t.o.v. NAP", unit_in="[cm]", index=row_idx),
+            hoogte_tov_onderzijde_fundering_cm=table.get_value(header_in="Hoogte t.o.v. kesp/vloer", unit_in="[cm]", index=row_idx),
+            is_wankant_aanwezig=utils.parse_ja_nee(wankant_val) if wankant_val else None,
+            datum_monstername=table.get_value(header_in="Datum monstername", unit_in="[dd-mm-j\\]", index=row_idx),
         )
 
     def __hash__(self):

--- a/src/tekstherkenning_ark/models/houtmonster.py
+++ b/src/tekstherkenning_ark/models/houtmonster.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
-from pydantic import BaseModel
 
 from azure.ai.documentintelligence.models import DocumentTable
 
 from tekstherkenning_ark import utils
-from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaatType, OnverwachtResultaat
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
 
 

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -78,11 +78,15 @@ class Kesp(RakBaseModel):
 
         # Get the kespnummer column to identify valid kesp rows
         kesp_nummer_col = structured_table.get_column(header_in="Kespnummer", unit_in="[Ky]")
-        constructie_id_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")
+        opmerkingen_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")
 
         # Special case: constructie id staat niet in de opmerkingen maar in de kesp id kolom
-        if not any("constructie" in str(val).lower() for val in constructie_id_col.values):
-            constructie_id_col = kesp_nummer_col
+        if opmerkingen_col is None or not any("constructie" in str(val).lower() for val in opmerkingen_col.values):
+            if opmerkingen_col is None:
+                logger.warning("Could not find constructie ID column in table based on header 'Opmerkingen'. ")
+            else:
+                logger.warning("Could not find any constructie ID values in column with header 'Opmerkingen'.")
+            opmerkingen_col = kesp_nummer_col
 
         if not kesp_nummer_col:
             logger.error("Could not find kespnummer column in table")
@@ -96,7 +100,7 @@ class Kesp(RakBaseModel):
 
         for row_idx in range(num_rows):
 
-            constructie_id_col_val = utils.clean_string(constructie_id_col.values[row_idx])
+            constructie_id_col_val = utils.clean_string(opmerkingen_col.values[row_idx])
 
             if "constructie" in constructie_id_col_val.lower():
                 current_constructie_id = constructie_id_col_val

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -5,6 +5,7 @@ from tekstherkenning_ark.enums import NietBeschikbaar
 from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
 from tekstherkenning_ark.logger import get_logger
+from tekstherkenning_ark.document.structured_table import StructuredTable
 
 logger = get_logger(__name__)
 
@@ -61,13 +62,13 @@ class Kesp(RakBaseModel):
         return self.kesp_nummer
 
     @classmethod
-    def from_doc_tables(cls, rows: list[list[str]]) -> dict[str, list[Kesp]]:
-        """Parse and return a list of Kesp objects from table rows.
+    def from_doc_tables(cls, structured_table: StructuredTable) -> dict[str, list[Kesp]]:
+        """Parse and return a list of Kesp objects from a structured table.
 
         Parameters
         ----------
-        rows : list[list[str]]
-            List of table rows as lists of strings.
+        structured_table : StructuredTable
+            Structured table containing kesp data with expected headers and sub-headers.
 
         Returns
         -------
@@ -75,41 +76,60 @@ class Kesp(RakBaseModel):
             A dictionary mapping constructie ID's to lists of Kesp objects containing information from the table
         """
 
-        # Skip header rows and filter to kesp rows
-        kesp_rows = [r for r in rows if utils.contains_kesp_id(r[0])]
+        # Get the kespnummer column to identify valid kesp rows
+        kesp_nummer_col = structured_table.get_column(header_in="Kespnummer", unit_in="[Ky]")
+        constructie_id_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")
+
+        # Special case: constructie id staat niet in de opmerkingen maar in de kesp id kolom
+        if not any("constructie" in str(val).lower() for val in constructie_id_col.values):
+            constructie_id_col = kesp_nummer_col
+
+        if not kesp_nummer_col:
+            logger.error("Could not find kespnummer column in table")
+            return {}
 
         # Parse each row into a Kesp object
         kesp_dict: dict[str, list[Kesp]] = {}
         current_constructie_id = ""
 
-        for row in kesp_rows:
+        num_rows = len(kesp_nummer_col.values)
 
-            constructie_id_col_val = row[11].strip()
+        for row_idx in range(num_rows):
 
-            if constructie_id_col_val != "":
+            constructie_id_col_val = utils.clean_string(constructie_id_col.values[row_idx])
+
+            if "constructie" in constructie_id_col_val.lower():
                 current_constructie_id = constructie_id_col_val
 
+                if current_constructie_id in kesp_dict:
+                    logger.warning(f"Duplicate constructie ID found: {current_constructie_id}")
+
+            kesp_nummer_val = kesp_nummer_col.values[row_idx]
+
+            if utils.contains_kesp_id(kesp_nummer_val):
+                kesp = cls.from_kesp_table_row(structured_table, row_idx)
+
+                # Add kesp to the correct constructie ID list
                 if current_constructie_id not in kesp_dict:
                     kesp_dict[current_constructie_id] = []
-                else:
-                    logger.critical(f"Duplicate constructie ID found: {current_constructie_id}")
-                    # raise ValueError(f"Duplicate constructie ID found: {current_constructie_id}")
+                kesp_dict[current_constructie_id].append(kesp)
 
-            if current_constructie_id != "":
-                paal = cls.from_kesp_table_row(row)
-                kesp_dict[current_constructie_id].append(paal)
+        if "" in kesp_dict:
+            logger.warning(f"{len(kesp_dict[''])} kespen found with constructie ID missing.")
 
         return kesp_dict
 
     @classmethod
-    def from_kesp_table_row(cls, row: list[str]) -> Kesp:
+    def from_kesp_table_row(cls, table: StructuredTable, row_idx: int) -> Kesp:
         """Parse and return a Kesp object from a single row of the
-        kespen table.
+        kespen structured table.
 
         Parameters
         ----------
-        row : list[str]
-            A single row from the kespen table as a list of strings.
+        table : StructuredTable
+            Structured table containing kesp data.
+        row_idx : int
+            Index of the row to parse.
 
         Returns
         -------
@@ -117,18 +137,36 @@ class Kesp(RakBaseModel):
             A Kesp object containing information from the row.
         """
 
-        row_clean = [utils.clean_string(val) for val in row]
+        opsluitklos_aanwezig_val = table.get_value(
+            header_in="Opsluitklos", sub_header_in="Aanwezig? Aanwezig?", unit_in="[Ja/Nee]", index=row_idx
+        )
 
         return cls(
-            kesp_nummer=row_clean[0],
-            hoogte_cm=row_clean[1],
-            breedte_cm=row_clean[2],
-            hoek_tov_lengte_as_graden=row_clean[3],
-            lengte_uitstekend_deel_cm=row_clean[4],
-            mate_inknijping_cm=row_clean[5],
-            indrukking_paal_in_kesp_cm=row_clean[6],
-            is_opsluitklos_aanwezig=utils.parse_ja_nee(row_clean[7]) if row_clean[7] != "" else None,
-            is_opsluitklos_aangetast=utils.parse_ja_nee(row_clean[8]),
-            is_vervormd=utils.parse_ja_nee(row_clean[9]),
-            is_aangetast=utils.parse_ja_nee(row_clean[10]),
+            kesp_nummer=table.get_value(header_in="Kespnummer", unit_in="[Ky]", index=row_idx),
+            hoogte_cm=table.get_value(header_in="Afmetingen", sub_header_in="Hoogte", unit_in="[cm]", index=row_idx),
+            breedte_cm=table.get_value(header_in="Afmetingen", sub_header_in="Breedte", unit_in="[cm]", index=row_idx),
+            hoek_tov_lengte_as_graden=table.get_value(
+                header_in="Hoek t.o.v. lengte-as frontwand", unit_in="[]", index=row_idx
+            ),
+            lengte_uitstekend_deel_cm=table.get_value(
+                header_in="Lengte uitstekende deel t.o.v. voorzijde frontwand", unit_in="[cm]", index=row_idx
+            ),
+            mate_inknijping_cm=table.get_value(
+                header_in="Mate van inknijping to.v. oorspronkelijke staat", unit_in="0", index=row_idx
+            ),
+            indrukking_paal_in_kesp_cm=table.get_value(
+                header_in="Indrukking van de funderingspaal in de kesp", unit_in="[Ja/Nee]", index=row_idx
+            ),
+            is_opsluitklos_aanwezig=(
+                utils.parse_ja_nee(opsluitklos_aanwezig_val) if opsluitklos_aanwezig_val != "" else None
+            ),
+            is_opsluitklos_aangetast=utils.parse_ja_nee(
+                table.get_value(header_in="Opsluitklos", sub_header_in="Aantasting", unit_in="[Ja/Nee]", index=row_idx)
+            ),
+            is_vervormd=utils.parse_ja_nee(
+                table.get_value(header_in="Schades", sub_header_in="Vervormingen", unit_in="[Ja/Nee]", index=row_idx)
+            ),
+            is_aangetast=utils.parse_ja_nee(
+                table.get_value(header_in="Schades", sub_header_in="Aantasting", unit_in="[Ja/Nee]", index=row_idx)
+            ),
         )

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -152,7 +152,12 @@ class Kesp(RakBaseModel):
                 header_in="Lengte uitstekende deel t.o.v. voorzijde frontwand", unit_in="[cm]", index=row_idx
             ),
             mate_inknijping_cm=table.get_value(
-                header_in="Mate van inknijping to.v. oorspronkelijke staat", unit_in="0", index=row_idx
+                header_in=[
+                    "Mate van inknijping to.v. oorspronkelijke staat",
+                    "Mate van inknijping Lo.v. oorspronkelijke staat",
+                ],
+                unit_in="0",
+                index=row_idx,
             ),
             indrukking_paal_in_kesp_cm=table.get_value(
                 header_in="Indrukking van de funderingspaal in de kesp", unit_in="[Ja/Nee]", index=row_idx

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -53,9 +53,6 @@ class Kesp(RakBaseModel):
     # Te vinden in Bijlage 3, kolom 'Schades Aantasting'.
     is_aangetast: bool | NietBeschikbaar | None = None
 
-    # TBD waar te vinden
-    paalrij_nr: str | None = None
-
     @property
     def identifier(self) -> str:
         """Return a string that uniquely identifies this Kesp instance."""

--- a/src/tekstherkenning_ark/models/onverwacht_resultaat.py
+++ b/src/tekstherkenning_ark/models/onverwacht_resultaat.py
@@ -4,9 +4,7 @@ Module defining the UnexpectedResult for handling unexpected results in the teks
 
 from enum import Enum
 from typing import Any
-from pydantic import BaseModel, ValidationError, model_validator
-from pydantic_core import core_schema
-from typing import Any as AnyType
+from pydantic import BaseModel, model_validator
 from tekstherkenning_ark.logger import get_logger
 
 logger = get_logger(__name__)
@@ -48,30 +46,3 @@ class OnverwachtResultaat(BaseModel):
             f"Value: {self.waarde}, Details: {self.details}"
         )
         return self
-
-    @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: AnyType, handler):
-        """Define custom Pydantic validation schema that catches validation errors."""
-        python_schema = handler(source_type)
-
-        def validate_with_fallback(value, handler):
-            """Wrap validator that catches validation errors for union types."""
-            # If it's already an OnverwachtResultaat, return it
-            if isinstance(value, OnverwachtResultaat):
-                return value
-
-            # Try to validate with the original schema
-            try:
-                return handler(value)
-            except ValidationError as e:
-                # If validation fails, wrap in OnverwachtResultaat
-                return OnverwachtResultaat(
-                    waarde=value,
-                    onverwacht_resultaat_type=OnverwachtResultaatType.INCORRECT_TYPE,
-                    details=f"Validation error: {str(e)}",
-                )
-
-        return core_schema.no_info_wrap_validator_function(
-            validate_with_fallback,
-            python_schema,
-        )

--- a/src/tekstherkenning_ark/models/paal.py
+++ b/src/tekstherkenning_ark/models/paal.py
@@ -8,6 +8,7 @@ from tekstherkenning_ark.models.houtmonster import Houtmonster
 from tekstherkenning_ark.models.rak_base_model import RakBaseModel
 from tekstherkenning_ark.logger import get_logger
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
+from tekstherkenning_ark.document.structured_table import StructuredTable
 
 logger = get_logger(__name__)
 
@@ -99,13 +100,13 @@ class Paal(RakBaseModel):
         return int(self.paal_nummer.split(".")[1])
 
     @classmethod
-    def from_doc_tables(cls, rows: list[list[str]]) -> dict[str, list[Paal]]:
-        """Parse and return a list of Paal objects from table rows.
+    def from_doc_tables(cls, structured_table: StructuredTable) -> dict[str, list[Paal]]:
+        """Parse and return a list of Paal objects from a structured table.
 
         Parameters
         ----------
-        rows : list[list[str]]
-            List of table rows as lists of strings.
+        structured_table : StructuredTable
+            Structured table containing paal data with expected headers and sub-headers.
 
         Returns
         -------
@@ -113,53 +114,71 @@ class Paal(RakBaseModel):
             A dictionary mapping constructie ID's to lists of Paal objects containing information from the table
         """
 
-        # Skip header rows and filter to paal rows
-        paal_rows = [r for r in rows if utils.contains_paal_id(r[0])]
+        # Get the paalnummer column to identify valid paal rows
+        paal_nummer_col = structured_table.get_column(header_in="Paalnummer", unit_in="[Px.y]")
+        constructie_id_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")
+
+        # Special case: constructie id staat niet in de opmerkingen maar in de paal id kolom
+        if not any("constructie" in str(val).lower() for val in constructie_id_col.values):
+            constructie_id_col = paal_nummer_col
+
+        if not paal_nummer_col:
+            logger.error("Could not find paalnummer column in table")
+            return {}
 
         # Parse each row into a Paal object
         paal_dict: dict[str, list[Paal]] = {}
         current_constructie_id = ""
 
-        last_main_paal_nummer = 0
+        num_rows = len(paal_nummer_col.values)
 
-        for row in paal_rows:
-            if len(row) != 17:
-                logger.warning(f"Onverwacht aantal kolommen in paal rij: verwacht 17, kreeg {len(row)}. Rij: {row}")
-                continue
-            constructie_id_col_val = utils.clean_string(row[16])
+        for row_idx in range(num_rows):
 
-            if constructie_id_col_val != "":
-                current_constructie_id = constructie_id_col_val  # TODO: dit gaat niet goed bij palen waar de rakdeelnaam boven de palen staat
+            constructie_id_col_val = utils.clean_string(constructie_id_col.values[row_idx])
+
+            if "constructie" in constructie_id_col_val.lower():
+                current_constructie_id = constructie_id_col_val
 
                 if current_constructie_id not in paal_dict:
                     paal_dict[current_constructie_id] = []
                 else:
                     logger.warning(f"Duplicate constructie ID found: {current_constructie_id}")
 
-            if current_constructie_id != "":
-                paal = cls.from_paal_table_row(row)
+            paal_nummer_val = paal_nummer_col.values[row_idx]
 
-                # Validate paal nummers are sequential
-                if not paal.paal_nummer_main in [last_main_paal_nummer, last_main_paal_nummer + 1]:
-                    logger.warning(
-                        f"Paal nummers are not sequential. Expected {last_main_paal_nummer} or {last_main_paal_nummer + 1}, got {paal.paal_nummer_main} for {paal.paal_nummer}. \nLast 5 palen: {[p.paal_nummer for p in paal_dict[current_constructie_id][-5:]]}"
-                    )
-                last_main_paal_nummer = paal.paal_nummer_main
+            if utils.contains_paal_id(paal_nummer_val):
+                paal = cls.from_paal_table_row(structured_table, row_idx)
 
                 # Add paal to the correct constructie ID list
                 paal_dict[current_constructie_id].append(paal)
 
+        # Validate paal nummers are sequential within each constructie ID
+        prev_main_paal_nummer = 0
+
+        for constructie_id, palen in paal_dict.items():
+            for paal in palen:
+                if not paal.paal_nummer_main in [prev_main_paal_nummer, prev_main_paal_nummer + 1]:
+                    logger.warning(
+                        f"Paal nummers are not sequential within constructie ID {constructie_id}. Expected {prev_main_paal_nummer} or {prev_main_paal_nummer + 1}, got {paal.paal_nummer_main} for {paal.paal_nummer}"
+                    )
+                prev_main_paal_nummer = paal.paal_nummer_main
+
+        if "" in paal_dict:
+            logger.warning(f"{len(paal_dict[''])} palen found with constructie ID missing.")
+
         return paal_dict
 
     @classmethod
-    def from_paal_table_row(cls, row: list[str]) -> Paal:
+    def from_paal_table_row(cls, table: StructuredTable, row_idx: int) -> Paal:
         """Parse and return a Paal object from a single row of the
-        funderingspalen table.
+        funderingspalen structured table.
 
         Parameters
         ----------
-        row : list[str]
-            A single row from the funderingspalen table as a list of strings.
+        table : StructuredTable
+            Structured table containing paal data.
+        row_idx : int
+            Index of the row to parse.
 
         Returns
         -------
@@ -167,34 +186,35 @@ class Paal(RakBaseModel):
             A Paal object containing information from the row.
         """
 
-        row_clean = [utils.clean_string(val) for val in row]
         return cls(
-            paal_nummer=utils.clean_paal_id(row_clean[0]),
-            diameter_haaks=row_clean[1],
-            diameter_parallel=row_clean[2],
-            diameter_gemiddeld=row_clean[3],
-            hoh_afstand_cm=row_clean[4],
-            hoh_paalnummer=row_clean[5],
-            schoor_graden=row_clean[8],
-            schoor_richting=row_clean[9],
-            afstand_frontwand_cm=row_clean[10],
-            is_scheefstand=utils.parse_ja_nee(row_clean[11]),
-            is_paalbreuk=utils.parse_ja_nee(row_clean[12]),
-            is_aantasting=utils.parse_ja_nee(row_clean[13]),
-            aansluiting_status=row_clean[14],
-            positionering_aansluiting_cm=row_clean[15],
+            paal_nummer=utils.clean_paal_id(table.get_value(header_in="Paalnummer", unit_in="[Px.y]", index=row_idx)),
+            diameter_haaks=table.get_value("Diameter", "Haaks", "[mm]", row_idx),
+            diameter_parallel=table.get_value("Diameter", "Parrallel", "[mm]", row_idx),
+            diameter_gemiddeld=table.get_value("Diameter", "Gemiddelde", "[mm]", row_idx),
+            hoh_afstand_cm=table.get_value("Hart-op-hart-afstanden", "Afstand", "[cm]", row_idx),
+            hoh_paalnummer=table.get_value("Hart-op-hart-afstanden", ["Paal", "aa"], "[Px.y]", row_idx),
+            schoor_graden=table.get_value("Schoorstand", "Graden", "[]", row_idx),
+            schoor_richting=table.get_value("Schoorstand", "Richting", "[+ ]", row_idx),
+            afstand_frontwand_cm=table.get_value("Afstand", "Frontwand", "[cm]", row_idx),
+            is_scheefstand=utils.parse_ja_nee(table.get_value("Schades", "Scheefstand", "[Ja/Nee]", row_idx)),
+            is_paalbreuk=utils.parse_ja_nee(table.get_value("Schades", "Paalbreuk", "[Ja/Nee]", row_idx)),
+            is_aantasting=utils.parse_ja_nee(table.get_value("Schades", "Aantasting", "[Ja/Nee]", row_idx)),
+            aansluiting_status=table.get_value("Aansluiting", "Aansluiting", "[G/S]", row_idx),
+            positionering_aansluiting_cm=table.get_value("Aansluiting", "Positionering", "[+]+[cm]", row_idx),
         )
 
 
 if __name__ == "__main__":
 
     from tekstherkenning_ark.document.smart_document import SmartDocument
+    from tekstherkenning_ark.document.structured_table import StructuredTable, TableColumn
     from tekstherkenning_ark import constants
 
     doc = SmartDocument.from_pdf(constants.TEST_PDF_PATH)
 
-    paal_tables = doc.get_meettabel_fundering_paal()
-    palen_dict = Paal.from_doc_tables(paal_tables)
+    palen_table = doc.get_meettabel_fundering_paal()
+
+    palen_dict = Paal.from_doc_tables(palen_table)
 
     for palen in palen_dict.values():
         for paal in palen:

--- a/src/tekstherkenning_ark/models/paal.py
+++ b/src/tekstherkenning_ark/models/paal.py
@@ -116,11 +116,14 @@ class Paal(RakBaseModel):
 
         # Get the paalnummer column to identify valid paal rows
         paal_nummer_col = structured_table.get_column(header_in="Paalnummer", unit_in="[Px.y]")
-        constructie_id_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")
+        opmerkingen_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")
 
-        # Special case: constructie id staat niet in de opmerkingen maar in de paal id kolom
-        if not any("constructie" in str(val).lower() for val in constructie_id_col.values):
-            constructie_id_col = paal_nummer_col
+        if opmerkingen_col is None or not any("constructie" in str(val).lower() for val in opmerkingen_col.values):
+            if opmerkingen_col is None:
+                logger.warning("Could not find constructie ID column in table based on header 'Opmerkingen'. ")
+            else:
+                logger.warning("Could not find any constructie ID values in column with header 'Opmerkingen'.")
+            opmerkingen_col = paal_nummer_col
 
         if not paal_nummer_col:
             logger.error("Could not find paalnummer column in table")
@@ -134,14 +137,12 @@ class Paal(RakBaseModel):
 
         for row_idx in range(num_rows):
 
-            constructie_id_col_val = utils.clean_string(constructie_id_col.values[row_idx])
+            constructie_id_col_val = utils.clean_string(opmerkingen_col.values[row_idx])
 
             if "constructie" in constructie_id_col_val.lower():
                 current_constructie_id = constructie_id_col_val
 
-                if current_constructie_id not in paal_dict:
-                    paal_dict[current_constructie_id] = []
-                else:
+                if current_constructie_id in paal_dict:
                     logger.warning(f"Duplicate constructie ID found: {current_constructie_id}")
 
             paal_nummer_val = paal_nummer_col.values[row_idx]
@@ -150,6 +151,8 @@ class Paal(RakBaseModel):
                 paal = cls.from_paal_table_row(structured_table, row_idx)
 
                 # Add paal to the correct constructie ID list
+                if current_constructie_id not in paal_dict:
+                    paal_dict[current_constructie_id] = []
                 paal_dict[current_constructie_id].append(paal)
 
         # Validate paal nummers are sequential within each constructie ID

--- a/src/tekstherkenning_ark/models/paal.py
+++ b/src/tekstherkenning_ark/models/paal.py
@@ -45,24 +45,11 @@ class Paal(RakBaseModel):
     # Te vinden in de schades en gebreken tabellen van hoofdstuk 5.
     gebreken: list[Gebrek] = []
 
-    # TODO Waar te vinden? - MT
-    paalrij_nummer: str = ""
-
     # Te vinden in de meettabel funderingspalen, Bijlage 3, kolom 'Paalnummer'.
     paal_nummer: str
 
     # Te vinden in de meettabel funderingspalen, Bijlage 3, kolom 'Onderzocht'.
     is_onderzocht: bool | None = None
-
-    # Te vinden in de meettabel funderingspalen, Bijlage 3, kolom 'Schoorstand'.
-    schoorstand_graden: float | None = None
-    scheefstand: bool | None = None
-    materiaal: MateriaalOnderbouw | None = None
-
-    @property
-    def identifier(self) -> str:
-        """Return a string that uniquely identifies this Paal instance."""
-        return str(self.paal_nummer)
 
     # Te vinden in de meettabel funderingspalen, Bijlage 3, kolommen 'diameter'.
     diameter_haaks: int | NietBeschikbaar
@@ -92,6 +79,11 @@ class Paal(RakBaseModel):
     # Te vinden in bijlage 2 en houtmonsters csv.
     # Te vinden in Bijlage 1, kolom 'Paalnummer' en 'Houtmonster'. @Sammie welke van deze twee is waar?
     houtmonsters: list[Houtmonster] = []
+
+    @property
+    def identifier(self) -> str:
+        """Return a string that uniquely identifies this Paal instance."""
+        return str(self.paal_nummer)
 
     @property
     def paal_nummer_main(self) -> int:

--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -272,6 +272,14 @@ class Rak(RakBaseModel):
         # totale_lengte_m = doc.get_rak_totale_lengte_m()
         # opmerkingen = doc.get_rak_opmerkingen()
 
+        # Validate all constructie ids in palen and kespen are present in rakdelen, otherwise log a warning
+        rakdeel_ids = sorted([rd.rakdeel_id for rd in rakdelen])
+        gevonden_constructie_ids = sorted(list(set(list(palen_dict.keys()) + list(kespen_dict.keys()))))
+        for constructie_id in gevonden_constructie_ids:
+            if not any(constructie_id.lower().startswith(rakdeel_id.lower()) for rakdeel_id in rakdeel_ids):
+                logger.warning(f"Constructie ID '{constructie_id}' found in palen/kespen but not in rakdelen")
+
+        # Create rak instance
         rak_instance = cls(
             rakdelen=list(rakdelen),
             raknaam=raknaam,

--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -224,14 +224,14 @@ class Rak(RakBaseModel):
         raknaam = doc.get_raknaam()
 
         # Laad palen, kespen en houtmonsters uit tabellen
-        paal_tables = doc.get_meettabel_fundering_paal()
-        palen_dict = Paal.from_doc_tables(paal_tables)
+        paal_structured_table = doc.get_meettabel_fundering_paal()
+        palen_dict = Paal.from_doc_tables(paal_structured_table)
 
-        kesp_tables = doc.get_meettabel_fundering_kesp()
-        kespen_dict = Kesp.from_doc_tables(kesp_tables)
+        kesp_structured_table = doc.get_meettabel_fundering_kesp()
+        kespen_dict = Kesp.from_doc_tables(kesp_structured_table)
 
-        houtmonster_tables = doc.get_meettabel_houtmonsters()
-        houtmonsters = Houtmonster.from_doc_tables(houtmonster_tables)
+        houtmonster_structured_table = doc.get_meettabel_houtmonsters()
+        houtmonsters = Houtmonster.from_doc_tables(houtmonster_structured_table)
 
         # Plaats houtmonsters onder juiste palen
         processed_houtmonsters: set[Houtmonster] = set()

--- a/src/tekstherkenning_ark/models/rak_base_model.py
+++ b/src/tekstherkenning_ark/models/rak_base_model.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
-from typing import get_args, get_origin, Union
-from pydantic import BaseModel
+from typing import get_args, get_origin, Union, Annotated, Any
+from pydantic import BaseModel, ValidationError, field_validator
+from pydantic.functional_validators import WrapValidator
 
 from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
+
+
+def validate_with_onverwacht_fallback(value: Any, handler, info) -> Any:
+    """Validator that wraps values in OnverwachtResultaat if validation fails."""
+    # If already an OnverwachtResultaat, return it
+    if isinstance(value, OnverwachtResultaat):
+        return value
+
+    # Try normal validation
+    try:
+        return handler(value)
+    except ValidationError as e:
+        # If validation fails, wrap in OnverwachtResultaat
+        from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaatType
+
+        return OnverwachtResultaat(
+            waarde=value,
+            onverwacht_resultaat_type=OnverwachtResultaatType.INCORRECT_TYPE,
+            details=f"Validation error: {str(e)}",
+        )
 
 
 class RakBaseModel(BaseModel):
@@ -29,18 +50,23 @@ class RakBaseModel(BaseModel):
                 origin = get_origin(attr_type)
                 is_collection = origin in (list, tuple, set, frozenset, dict)
 
-                # If not a collection, add OnverwachtResultaat as a union type
+                # If not a collection, add OnverwachtResultaat as a union type with validator
                 if not is_collection:
                     # Check if OnverwachtResultaat is already in the type
                     if get_origin(attr_type) is Union:
                         args = get_args(attr_type)
                         if OnverwachtResultaat not in args:
-                            new_annotations[attr_name] = Union[attr_type, OnverwachtResultaat]
+                            # Add as Annotated with wrap validator
+                            new_annotations[attr_name] = Annotated[
+                                Union[attr_type, OnverwachtResultaat], WrapValidator(validate_with_onverwacht_fallback)
+                            ]
                         else:
                             new_annotations[attr_name] = attr_type
                     else:
-                        # Add OnverwachtResultaat to the type
-                        new_annotations[attr_name] = Union[attr_type, OnverwachtResultaat]
+                        # Add OnverwachtResultaat to the type with wrap validator
+                        new_annotations[attr_name] = Annotated[
+                            Union[attr_type, OnverwachtResultaat], WrapValidator(validate_with_onverwacht_fallback)
+                        ]
                 else:
                     new_annotations[attr_name] = attr_type
 

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -145,7 +145,7 @@ class Rakdeel(RakBaseModel):
         constructieonderdeel_rows = [r for r in rows if r and r[0] != expected_headers[0]]
 
         dict_toestandsbepaling: dict[str, bool | NietBeschikbaar | OnverwachtResultaat] = {}
-        if len(constructieonderdeel_rows) == 2:
+        if all((len(row) == 2 for row in constructieonderdeel_rows)):
             for constructieonderdeel, aangetast in constructieonderdeel_rows:
                 constructieonderdeel_clean = utils.clean_string(constructieonderdeel)
                 aangetast_clean = utils.parse_ja_nee(utils.clean_string(aangetast))

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -26,6 +26,7 @@ from tekstherkenning_ark.models.onderbouw import Onderbouw
 from tekstherkenning_ark.models.kesp import Kesp
 from tekstherkenning_ark.utils import contains_kesp_id, get_kesp_id, get_paal_id
 from tekstherkenning_ark.logger import get_logger
+from tekstherkenning_ark.document.structured_table import StructuredTable
 
 logger = get_logger(__name__)
 
@@ -92,7 +93,7 @@ class Rakdeel(RakBaseModel):
         onderdeel_is_aangetast = cls.from_toestandbepaling_table(section.toestand_tabel)
 
         # Parse gebrekentabel
-        gebreken = await Gebrek.from_doc_tables(rows=section.gebreken_tabel)
+        gebreken = await Gebrek.from_doc_tables(section.gebreken_tabel)
 
         # Verkrijg palen en kespen voor dit rakdeel
         palen = cls.get_for_constructie_naam(section.constructie_naam, palen_dict)
@@ -137,23 +138,47 @@ class Rakdeel(RakBaseModel):
 
     @staticmethod
     def from_toestandbepaling_table(
-        rows: list[list[str]],
+        structured_table: StructuredTable | None,
     ) -> dict[str, bool | NietBeschikbaar | OnverwachtResultaat]:
-        expected_headers = ["Constructieonderdeel", "Aangetast"]
+        """Parse toestandsbepaling table from structured table.
 
-        # Skip header rows
-        constructieonderdeel_rows = [r for r in rows if r and r[0] != expected_headers[0]]
+        Parameters
+        ----------
+        structured_table : StructuredTable | None
+            Structured table containing toestandsbepaling data.
 
+        Returns
+        -------
+        dict[str, bool | NietBeschikbaar | OnverwachtResultaat]
+            Dictionary mapping construction components to their condition status.
+        """
         dict_toestandsbepaling: dict[str, bool | NietBeschikbaar | OnverwachtResultaat] = {}
-        if len(constructieonderdeel_rows) == 2:
-            for constructieonderdeel, aangetast in constructieonderdeel_rows:
-                constructieonderdeel_clean = utils.clean_string(constructieonderdeel)
-                aangetast_clean = utils.parse_ja_nee(utils.clean_string(aangetast))
+
+        if structured_table is None:
+            logger.warning("Geen toestandsbepaling tabel gevonden")
+            return dict_toestandsbepaling
+
+        # Get columns
+        constructieonderdeel_col = structured_table.get_column(header_in="Constructieonderdeel")
+        aangetast_col = structured_table.get_column(header_in="Aangetast")
+
+        if not constructieonderdeel_col or not aangetast_col:
+            logger.error("Could not find required columns in toestandsbepaling table")
+            return dict_toestandsbepaling
+
+        num_rows = len(constructieonderdeel_col.values)
+
+        for row_idx in range(num_rows):
+            constructieonderdeel = utils.clean_string(constructieonderdeel_col.values[row_idx])
+            aangetast = utils.clean_string(aangetast_col.values[row_idx])
+
+            if constructieonderdeel:  # Skip empty rows
+                aangetast_clean = utils.parse_ja_nee(aangetast)
                 if isinstance(aangetast_clean, (bool, NietBeschikbaar, OnverwachtResultaat)):
-                    dict_toestandsbepaling[constructieonderdeel_clean] = aangetast_clean
+                    dict_toestandsbepaling[constructieonderdeel] = aangetast_clean
                 else:
-                    print(
-                        f"Waarschuwing: Onverwacht resultaat '{aangetast_clean}' voor '{constructieonderdeel_clean}', wordt overgeslagen."
+                    logger.warning(
+                        f"Onverwacht resultaat '{aangetast_clean}' voor '{constructieonderdeel}', wordt overgeslagen."
                     )
 
         return dict_toestandsbepaling

--- a/src/tekstherkenning_ark/utils.py
+++ b/src/tekstherkenning_ark/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 import re
 from azure.ai.documentintelligence.models import DocumentTable
 from unidecode import unidecode
@@ -231,6 +232,7 @@ def remove_invalid_rows(table_rows: list[list[str]]) -> list[list[str]]:
     return [row for row in table_rows if len(row) == max_kolommen]
 
 
+@cache
 def clean_string(value: str) -> str:
     """Clean an input string"""
 

--- a/src/tekstherkenning_ark/utils.py
+++ b/src/tekstherkenning_ark/utils.py
@@ -6,7 +6,7 @@ from unidecode import unidecode
 
 from tekstherkenning_ark.enums import NietBeschikbaar
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
@@ -49,6 +49,9 @@ def get_table_content(table: DocumentTable) -> list[list[str]]:
 def parse_ja_nee(value: str) -> bool | NietBeschikbaar | OnverwachtResultaat:
     """Parse a Ja/Nee string to a boolean value."""
     from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat, OnverwachtResultaatType
+
+    if value is None:
+        return None
 
     if value.strip().lower().startswith("ja"):
         return True
@@ -244,3 +247,33 @@ def clean_string(value: str) -> str:
     value = value.strip()
 
     return value
+
+
+def is_table_type_by_id_func(
+    tabel: DocumentTable, id_func: Callable[[str], str | None], threshold: float = 0.5
+) -> bool:
+    """Check of een tabel bij een type hoort op basis van een ID-extractie functie.
+
+    Parameters
+    ----------
+    tabel : DocumentTable
+        De tabel om te controleren.
+    id_func : callable
+        Functie die een string neemt en een ID of None teruggeeft (bijv. get_paal_id).
+    threshold : float
+        Minimale fractie van cellen die moeten matchen.
+
+    Returns
+    -------
+    bool
+        True als de tabel voldoet aan het type.
+    """
+    if not tabel.cells:
+        return False
+
+    first_col_cells = [cell.content for cell in tabel.cells if cell.column_index == 0]
+    if not first_col_cells:
+        return False
+
+    matching_cells = sum(1 for cell in first_col_cells if id_func(cell) is not None)
+    return (matching_cells / len(first_col_cells)) > threshold

--- a/src/tekstherkenning_ark/utils.py
+++ b/src/tekstherkenning_ark/utils.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import re
 from azure.ai.documentintelligence.models import DocumentTable
 from unidecode import unidecode
 
 from tekstherkenning_ark.enums import NietBeschikbaar
-from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat, OnverwachtResultaatType
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
 
 # Regex patterns for ID extraction and validation
 PAAL_ID_PATTERN = r"\bP\d+\.\d+\b"
@@ -42,6 +47,7 @@ def get_table_content(table: DocumentTable) -> list[list[str]]:
 
 def parse_ja_nee(value: str) -> bool | NietBeschikbaar | OnverwachtResultaat:
     """Parse a Ja/Nee string to a boolean value."""
+    from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat, OnverwachtResultaatType
 
     if value.strip().lower().startswith("ja"):
         return True
@@ -53,13 +59,11 @@ def parse_ja_nee(value: str) -> bool | NietBeschikbaar | OnverwachtResultaat:
     try:
         return NietBeschikbaar(value.strip())
     except:
-        pass
-
-    return OnverwachtResultaat(
-        waarde=value,
-        onverwacht_resultaat_type=OnverwachtResultaatType.PARSING_FOUT,
-        details=f"Kan Ja/Nee waarde niet parsen o.b.v. : `{value}`",
-    )
+        return OnverwachtResultaat(
+            waarde=value,
+            onverwacht_resultaat_type=OnverwachtResultaatType.PARSING_FOUT,
+            details=f"Kan Ja/Nee waarde niet parsen o.b.v. : `{value}`",
+        )
 
 
 def clean_paal_id(value: str) -> str:

--- a/tests/test_houtmonster.py
+++ b/tests/test_houtmonster.py
@@ -18,7 +18,7 @@ def test_invalid_houtmonster():
         is_wankant_aanwezig=True,
         datum_monstername="2023-01-01",
         is_aangetast=False,
-        stichtingjaar=1990
+        stichtingjaar=1990,
     )
     assert isinstance(my_houtmonster.codering, OnverwachtResultaat)
 
@@ -35,9 +35,51 @@ def test_invalid_nee_houtmonster():
         is_wankant_aanwezig="nee",  # Invalid type, should be bool or OnverwachtResultaat
         datum_monstername="2023-01-01",
         is_aangetast="ee",
-        stichtingjaar=1990
+        stichtingjaar=1990,
     )
     assert isinstance(my_houtmonster.is_wankant_aanwezig, OnverwachtResultaat)
     assert my_houtmonster.is_wankant_aanwezig.waarde == "nee"
     assert isinstance(my_houtmonster.is_aangetast, OnverwachtResultaat)
     assert my_houtmonster.is_aangetast.waarde == "ee"
+
+
+def test_valid_houtmonster():
+    my_houtmonster = Houtmonster(
+        codering="C01",
+        rak_code="RK01",
+        paal_nummer="P001",
+        houtmonster_code="HM01",
+        diameter_paal_ter_hoogte_houtmonster_mm=300,
+        hoogte_onder_nap_cm=150,
+        hoogte_tov_onderzijde_fundering_cm=200,
+        is_wankant_aanwezig=False,
+        datum_monstername="2023-01-01",
+        is_aangetast=True,
+        stichtingjaar=1990,
+    )
+
+    for field in my_houtmonster.model_dump().values():
+        assert not isinstance(field, OnverwachtResultaat)
+
+
+def test_valid_houtmonster_str_ints():
+    my_houtmonster = Houtmonster(
+        codering="C01",
+        rak_code="RK01",
+        paal_nummer="P001",
+        houtmonster_code="HM01",
+        diameter_paal_ter_hoogte_houtmonster_mm="300",
+        hoogte_onder_nap_cm="150",
+        hoogte_tov_onderzijde_fundering_cm="200",
+        is_wankant_aanwezig=False,
+        datum_monstername="2023-01-01",
+        is_aangetast=True,
+        stichtingjaar=1990,
+    )
+
+    assert my_houtmonster.diameter_paal_ter_hoogte_houtmonster_mm == 300
+    assert my_houtmonster.hoogte_onder_nap_cm == 150
+    assert my_houtmonster.hoogte_tov_onderzijde_fundering_cm == 200
+
+    for field in my_houtmonster.model_dump().values():
+        assert not isinstance(field, OnverwachtResultaat)

--- a/tests/test_rak_base_model_integration.py
+++ b/tests/test_rak_base_model_integration.py
@@ -36,14 +36,13 @@ def test_paal_with_onverwacht_resultaat():
     # Pass a string where a float is expected
     paal = Paal(
         paal_nummer="P1.5",
-        schoorstand_graden="onleesbaar",
         diameter_haaks=150,
         diameter_parallel=140,
         diameter_gemiddeld=145,
         hoh_afstand_cm=80,
         hoh_paalnummer="P1.6",
         schoor_graden=5,
-        schoor_richting=SchoorStand.POSITIEF,
+        schoor_richting="verkeerde waarde",
         afstand_frontwand_cm=20,
         is_scheefstand=False,
         is_paalbreuk=False,
@@ -52,8 +51,8 @@ def test_paal_with_onverwacht_resultaat():
         positionering_aansluiting_cm="0",
     )
 
-    assert isinstance(paal.schoorstand_graden, OnverwachtResultaat)
-    assert paal.schoorstand_graden.waarde == "onleesbaar"
+    assert isinstance(paal.schoor_richting, OnverwachtResultaat)
+    assert paal.schoor_richting.waarde == "verkeerde waarde"
     assert paal.paal_nummer == "P1.5"
 
 
@@ -62,7 +61,6 @@ def test_paal_with_normal_values():
 
     paal = Paal(
         paal_nummer="P1.1",
-        schoorstand_graden=5.2,
         diameter_haaks=150,
         diameter_parallel=150,
         diameter_gemiddeld=150,
@@ -78,7 +76,7 @@ def test_paal_with_normal_values():
         positionering_aansluiting_cm="0",
     )
 
-    assert paal.schoorstand_graden == 5.2
+    assert paal.schoor_richting == SchoorStand.POSITIEF
     assert paal.paal_nummer == "P1.1"
 
 


### PR DESCRIPTION
fixes #70 , #77 , #34 

This has become quite a big PR...

Contains the following changes:
- Fix parsing issues `str` -> `int` (instead of getting OnverwachtResultaat)
- Remove duplicate fields from kesp and paal
- Add `StructuredTable` implementation for `SmartDocument`, which extracts table headers (header, subheader and unit) from document tables. This replaces the `list[list[str]]` output of the `SmartDocument` class for table data.
- Apply `StructuredTable` approach to `Paal`, `Kesp` and `Houtmonster` classes
- Assign correct Constructie ID to palen and kespen even if the constructie is named in the paal/kesp nummer column instead of the "opmerkingen" column. 
- Fix double logging bug
- Fix import bugs in `utils.py`