### PR TITLE
68 niet aan rakdeel toegedeelde objecten opslaan in rak

### DIFF
--- a/scripts/rak_to_excel.py
+++ b/scripts/rak_to_excel.py
@@ -23,9 +23,11 @@ from tekstherkenning_ark.document.smart_document import SmartDocument
 def main():
     """Hoofdfunctie voor het exporteren van Rak data naar Excel."""
     pdf_rapporten = [file for file in (constants.DATA_DIR / "duikrapporten").glob("*.pdf")]
-    docs = [SmartDocument.from_pdf(file) for file in pdf_rapporten]
-    for doc in docs:
-        if not "boor" in doc.pdf_path.stem.lower():
+
+    for file in pdf_rapporten:
+        if not "boor" in file.stem.lower():
+
+            doc = SmartDocument.from_pdf(file)
             print(f"Genereren van Rak object voor {doc.pdf_path.name}...")
             rak = Rak.from_smart_document(doc, use_caching=False)
             print("Exporteren naar Excel...")

--- a/src/tekstherkenning_ark/document/smart_document.py
+++ b/src/tekstherkenning_ark/document/smart_document.py
@@ -127,7 +127,9 @@ class SmartDocument:
         """
         for sectie in self.sections:
             if "meettabel houtmonsters" in sectie.titel.lower() and sectie.tabellen:
-                return StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.HOUTMONSTERS)
+                table = StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.HOUTMONSTERS)
+                if table:
+                    return table
 
         return None
 
@@ -142,8 +144,9 @@ class SmartDocument:
         for sectie in self.sections:
             if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
 
-                return StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.PALEN)
-
+                table = StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.PALEN)
+                if table:
+                    return table
         return None
 
     def get_meettabel_fundering_kesp(self) -> StructuredTable | None:
@@ -156,7 +159,9 @@ class SmartDocument:
         """
         for sectie in self.sections:
             if "meettabel fundering" in sectie.titel.lower() and sectie.tabellen:
-                return StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.KESPEN)
+                table = StructuredTable.from_doc_table(sectie.tabellen, table_type=TableType.KESPEN)
+                if table:
+                    return table
 
         return None
 

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -127,7 +127,7 @@ class StructuredTable:
         cls,
         tables: list[DocumentTable],
         table_type: TableType,
-    ) -> StructuredTable:
+    ) -> StructuredTable | None:
         """Parse and return a StructuredTable object from table rows.
 
         Parameters

--- a/src/tekstherkenning_ark/document/structured_table.py
+++ b/src/tekstherkenning_ark/document/structured_table.py
@@ -166,8 +166,8 @@ class StructuredTable:
         table_rows = cls.remove_rows_before_header(valid_table_rows, table_type)
 
         # If there is no data or there are no value rows, return an empty StructuredTable
-        if len(table_rows) <= table_type.values_offset:
-            return StructuredTable(columns=[], table_type=table_type)
+        if not table_rows or len(table_rows) <= table_type.values_offset:
+            return None
 
         # Transpose rows to columns
         columns = list(zip(*table_rows))
@@ -187,7 +187,7 @@ class StructuredTable:
         """Get a value from the structured table based on header, sub-header, unit and row index by matching against possible values. Matching is case-insensitive."""
 
         column = self.get_column(header_in, sub_header_in, unit_in)
-        if not column is None and column.values:
+        if column is not None and column.values:
             return clean_string(column.values[index])
 
         return None
@@ -217,6 +217,9 @@ class StructuredTable:
         TableColumn | None
             The matching TableColumn object or None if no match is found.
         """
+
+        if not self.columns:
+            return None
 
         # Convert single string inputs to lists for uniform processing
         if isinstance(header_in, str):
@@ -282,6 +285,9 @@ class StructuredTable:
     @classmethod
     def remove_rows_before_header(cls, table_rows: list[list[str]], table_type: TableType) -> list[list[str]]:
         """Remove rows before the header row based on the expected header column names for the given table type."""
+
+        if not table_rows:
+            return table_rows
 
         # Get the header row location
         first_header_row_index = next(

--- a/src/tekstherkenning_ark/models/gebrek.py
+++ b/src/tekstherkenning_ark/models/gebrek.py
@@ -57,7 +57,7 @@ class Gebrek(BaseModel):
             Een lijst van Gebrek instanties.
         """
         if structured_table is None:
-            logger.warning("Geen gebreken tabel gevonden")
+            logger.warning(f"Geen {cls.__name__.lower()} tabel gevonden")
             return []
 
         # Get columns

--- a/src/tekstherkenning_ark/models/gebrek.py
+++ b/src/tekstherkenning_ark/models/gebrek.py
@@ -5,6 +5,7 @@ from typing import Literal
 from pydantic import BaseModel
 
 from tekstherkenning_ark.utils import (
+    clean_string,
     get_paal_id,
     contains_kesp_id,
     contains_paal_id,
@@ -73,7 +74,7 @@ class Gebrek(BaseModel):
         list_gebreken = []
 
         for row_idx in range(structured_table.num_rows):
-            codering_val = codering_col.values[row_idx].strip() if codering_col else ""
+            codering_val = clean_string(codering_col.values[row_idx]) if codering_col else ""
 
             # Stop at empty or dash rows
             if codering_val == "-" or codering_val == "":

--- a/src/tekstherkenning_ark/models/gebrek.py
+++ b/src/tekstherkenning_ark/models/gebrek.py
@@ -65,16 +65,15 @@ class Gebrek(BaseModel):
         omschrijving_col = structured_table.get_column(header_in="Omschrijving")
         figuurnummer_col = structured_table.get_column(header_in="Figuurnummer")
 
-        if not codering_col or not omschrijving_col or not figuurnummer_col:
-            logger.error("Could not find required columns in gebreken table")
+        if not codering_col and not omschrijving_col and not figuurnummer_col:
+            logger.error("Could not find any required columns in gebreken table")
             return []
 
         # Parsing logica om Gebrek instanties te maken
         list_gebreken = []
-        num_rows = len(codering_col.values)
 
-        for row_idx in range(num_rows):
-            codering_val = codering_col.values[row_idx].strip()
+        for row_idx in range(structured_table.num_rows):
+            codering_val = codering_col.values[row_idx].strip() if codering_col else ""
 
             # Stop at empty or dash rows
             if codering_val == "-" or codering_val == "":
@@ -82,8 +81,8 @@ class Gebrek(BaseModel):
 
             gebrek_instance = cls(
                 codering=codering_val,
-                omschrijving=omschrijving_col.values[row_idx],
-                figuurnummer=figuurnummer_col.values[row_idx],
+                omschrijving=omschrijving_col.values[row_idx] if omschrijving_col else "",
+                figuurnummer=figuurnummer_col.values[row_idx] if figuurnummer_col else "",
             )
             list_gebreken.append(gebrek_instance)
 

--- a/src/tekstherkenning_ark/models/houtmonster.py
+++ b/src/tekstherkenning_ark/models/houtmonster.py
@@ -56,7 +56,7 @@ class Houtmonster(RakBaseModel):
         return str(self.codering)
 
     @classmethod
-    def from_doc_tables(cls, structured_table: StructuredTable) -> list[Houtmonster]:
+    def from_doc_tables(cls, structured_table: StructuredTable | None) -> list[Houtmonster]:
         """Parse and return a list of Houtmonster objects from a structured table.
 
         Parameters
@@ -69,7 +69,9 @@ class Houtmonster(RakBaseModel):
         list[Houtmonster]
             A list of Houtmonster objects containing information from the table.
         """
-
+        if structured_table is None:
+            logger.warning(f"Geen {cls.__name__.lower()} tabel gevonden")
+            return []
         # Get the codering column to identify valid houtmonster rows
         codering_col = structured_table.get_column(header_in="Codering", unit_in="[RAKxxxx/Px.y/HM]")
 

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -99,7 +99,7 @@ class Kesp(RakBaseModel):
 
             constructie_id_col_val = utils.clean_string(opmerkingen_col.values[row_idx])
 
-            if "constructie" in constructie_id_col_val.lower():
+            if constructie_id_col_val.lower().startswith("constructie"):
                 current_constructie_id = constructie_id_col_val
 
                 if current_constructie_id in kesp_dict:

--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -59,7 +59,7 @@ class Kesp(RakBaseModel):
         return self.kesp_nummer
 
     @classmethod
-    def from_doc_tables(cls, structured_table: StructuredTable) -> dict[str, list[Kesp]]:
+    def from_doc_tables(cls, structured_table: StructuredTable | None) -> dict[str, list[Kesp]]:
         """Parse and return a list of Kesp objects from a structured table.
 
         Parameters
@@ -72,7 +72,9 @@ class Kesp(RakBaseModel):
         dict[str, list[Kesp]]
             A dictionary mapping constructie ID's to lists of Kesp objects containing information from the table
         """
-
+        if structured_table is None:
+            logger.warning(f"Geen {cls.__name__.lower()} tabel gevonden")
+            return {}
         # Get the kespnummer column to identify valid kesp rows
         kesp_nummer_col = structured_table.get_column(header_in="Kespnummer", unit_in="[Ky]")
         opmerkingen_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")

--- a/src/tekstherkenning_ark/models/paal.py
+++ b/src/tekstherkenning_ark/models/paal.py
@@ -92,7 +92,7 @@ class Paal(RakBaseModel):
         return int(self.paal_nummer.split(".")[1])
 
     @classmethod
-    def from_doc_tables(cls, structured_table: StructuredTable) -> dict[str, list[Paal]]:
+    def from_doc_tables(cls, structured_table: StructuredTable | None) -> dict[str, list[Paal]]:
         """Parse and return a list of Paal objects from a structured table.
 
         Parameters
@@ -105,7 +105,9 @@ class Paal(RakBaseModel):
         dict[str, list[Paal]]
             A dictionary mapping constructie ID's to lists of Paal objects containing information from the table
         """
-
+        if structured_table is None:
+            logger.warning(f"Geen {cls.__name__.lower()} tabel gevonden")
+            return {}
         # Get the paalnummer column to identify valid paal rows
         paal_nummer_col = structured_table.get_column(header_in="Paalnummer", unit_in="[Px.y]")
         opmerkingen_col = structured_table.get_column(header_in="Opmerkingen", unit_in="[aanvullende tekst]")

--- a/src/tekstherkenning_ark/models/paal.py
+++ b/src/tekstherkenning_ark/models/paal.py
@@ -131,7 +131,7 @@ class Paal(RakBaseModel):
 
             constructie_id_col_val = utils.clean_string(opmerkingen_col.values[row_idx])
 
-            if "constructie" in constructie_id_col_val.lower():
+            if constructie_id_col_val.lower().startswith("constructie"):
                 current_constructie_id = constructie_id_col_val
 
                 if current_constructie_id in paal_dict:

--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -40,6 +40,10 @@ class Rak(RakBaseModel):
     # Te vinden in paragraaf 2.2.1 (paspoortgegevens) en/of de constructiebeschrijving (eerste zin van paragraaf 5.x).
     totale_lengte_m: float
 
+    unassigned_palen: list[Paal] = []
+    unassigned_kespen: list[Kesp] = []
+    unassigned_houtmonsters: list[Houtmonster] = []
+
     @property
     def identifier(self) -> str:
         """Return a string that uniquely identifies this Rak instance."""
@@ -233,24 +237,7 @@ class Rak(RakBaseModel):
         houtmonster_structured_table = doc.get_meettabel_houtmonsters()
         houtmonsters = Houtmonster.from_doc_tables(houtmonster_structured_table)
 
-        # Plaats houtmonsters onder juiste palen
-        processed_houtmonsters: set[Houtmonster] = set()
-        for _, palen in palen_dict.items():
-            for paal in palen:
-                paal.houtmonsters = [
-                    hm
-                    for hm in houtmonsters
-                    if paal.paal_nummer == hm.paal_nummer or paal.paal_nummer == hm.codering.split("/")[2]
-                ]
-                if paal.houtmonsters:
-                    processed_houtmonsters.update(set(paal.houtmonsters))
-
-        # Validate that all houtmonsters have been assigned to a paal
-        unprocessed_houtmonsters = set(houtmonsters) - processed_houtmonsters
-        if unprocessed_houtmonsters:
-            logger.warning(
-                f"The following houtmonsters could not be assigned to a paal: {[hm.codering for hm in unprocessed_houtmonsters]}"
-            )
+        cls.assign_houtmonsters_to_palen(palen_dict=palen_dict, houtmonsters=houtmonsters)
 
         # Maak rakdelen aan (parallel via async)
         rakdeel_sections = doc.get_rakdeel_secties()
@@ -287,9 +274,71 @@ class Rak(RakBaseModel):
             opmerkingen="",
         )
 
+        # Check if all palen, kespen and houtmonsters are correctly assigned to rakdelen
+        rak_instance.check_assigned_objects(palen_dict=palen_dict, kespen_dict=kespen_dict, houtmonsters=houtmonsters)
+
+        # Cache the created Rak instance
         cache_file.write_bytes(pickle.dumps(rak_instance))
 
         return rak_instance
+
+    @staticmethod
+    def assign_houtmonsters_to_palen(palen_dict: dict[str, list[Paal]], houtmonsters: list[Houtmonster]):
+        """Plaats houtmonsters onder juiste palen op basis van paal_nummer of codering."""
+
+        processed_houtmonsters: set[Houtmonster] = set()
+        for _, palen in palen_dict.items():
+            for paal in palen:
+                paal.houtmonsters = [
+                    hm
+                    for hm in houtmonsters
+                    if paal.paal_nummer == hm.paal_nummer or paal.paal_nummer == hm.codering.split("/")[2]
+                ]
+                if paal.houtmonsters:
+                    processed_houtmonsters.update(set(paal.houtmonsters))
+
+    def check_assigned_objects(
+        self, palen_dict: dict[str, list[Paal]], kespen_dict: dict[str, list[Kesp]], houtmonsters: list[Houtmonster]
+    ):
+        """Controleer of alle palen, kespen en houtmonsters correct zijn toegewezen aan rakdelen.
+        Indien niet, sla de niet toegewezen objecten op in het rak en log een waarschuwing."""
+
+        # Get assigned objects from rak object
+        assigned_palen = [p for _, p in self.alle_palen]
+        assigned_kespen = [k for _, k in self.alle_kespen]
+        assigned_houtmonsters = [hm for _, _, hm in self.alle_houtmonsters]
+
+        # Check for unassigned palen
+        unassigned_palen = []
+        for palen in palen_dict.values():
+            unassigned_palen.extend([p for p in palen if not p in assigned_palen])
+
+        # Check for unassigned kespen
+        unassigned_kespen = []
+        for kespen in kespen_dict.values():
+            unassigned_kespen.extend([k for k in kespen if not k in assigned_kespen])
+
+        # Check for unassigned houtmonsters
+        unassigned_houtmonsters = [hm for hm in houtmonsters if hm not in assigned_houtmonsters]
+
+        # Log warnings for unassigned objects
+        if unassigned_palen:
+            logger.warning(
+                f"{len(unassigned_palen)} palen could not be assigned to any rakdeel. Storing them in `unassigned_palen` list in Rak."
+            )
+            self.unassigned_palen = unassigned_palen
+
+        if unassigned_kespen:
+            logger.warning(
+                f"{len(unassigned_kespen)} kespen could not be assigned to any rakdeel. Storing them in `unassigned_kespen` list in Rak."
+            )
+            self.unassigned_kespen = unassigned_kespen
+
+        if unassigned_houtmonsters:
+            logger.warning(
+                f"{len(unassigned_houtmonsters)} houtmonsters could not be assigned to any paal. Storing them in `unassigned_houtmonsters` list in Rak."
+            )
+            self.unassigned_houtmonsters = unassigned_houtmonsters
 
 
 if __name__ == "__main__":

--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -62,6 +62,10 @@ class Rak(RakBaseModel):
         for rakdeel in self.rakdelen:
             for paal in rakdeel.onderbouw.palen:
                 resultaat.append((rakdeel.rakdeel_id, paal))
+
+        # Add unassigned palen
+        for paal in self.unassigned_palen:
+            resultaat.append(("unassigned", paal))
         return resultaat
 
     @property
@@ -77,6 +81,10 @@ class Rak(RakBaseModel):
         for rakdeel in self.rakdelen:
             for kesp in rakdeel.onderbouw.kespen:
                 resultaat.append((rakdeel.rakdeel_id, kesp))
+
+        # Add unassigned kespen
+        for kesp in self.unassigned_kespen:
+            resultaat.append(("unassigned", kesp))
         return resultaat
 
     @property
@@ -93,6 +101,10 @@ class Rak(RakBaseModel):
             for paal in rakdeel.onderbouw.palen:
                 for houtmonster in paal.houtmonsters:
                     resultaat.append((rakdeel.rakdeel_id, paal.paal_nummer, houtmonster))
+
+        # Add unassigned houtmonsters
+        for houtmonster in self.unassigned_houtmonsters:
+            resultaat.append(("unassigned", "unassigned", houtmonster))
         return resultaat
 
     def to_excel(self, export_dir: Path | None = None) -> Path:

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -67,6 +67,23 @@ class Rakdeel(RakBaseModel):
         """Return a string that uniquely identifies this Rakdeel instance."""
         return str(self.rakdeel_id)
 
+    # @property
+    # # TODO: Checken met geert of we dit wel willen implementeren, nu kan nog niet.
+    # def maximaal_aantal_scheuren_per_10_m(self) -> int | None:
+    #     """Aantal scheuren genormaliseerd naar 10 meter lengte."""
+    #     if self.lengte_m is None or self.lengte_m == 0:
+    #         return None
+    #     aantal_scheuren = self.bovenbouw.totaal_aantal_scheuren
+    #     return round((aantal_scheuren / self.lengte_m) * 10)
+
+    @property
+    def aantal_scheuren_per_meter(self) -> float | None:
+        """Scheur-dichtheid per meter."""
+        if self.lengte_m is None or self.lengte_m == 0:
+            return None
+        aantal_scheuren = self.bovenbouw.totaal_aantal_scheuren
+        return round(aantal_scheuren / self.lengte_m, 2)
+
     @classmethod
     async def from_smart_doc_section(
         cls, section: RakdeelSectie, kespen_dict: dict[str, list[Kesp]], palen_dict: dict[str, list[Paal]]
@@ -121,7 +138,7 @@ class Rakdeel(RakBaseModel):
         )
 
         # Add gebreken to rakdeel and subcomponents
-        rakdeel.assign_gebreken_to_children(gebreken)
+        rakdeel.add_gebreken(gebreken)
 
         return rakdeel
 
@@ -130,7 +147,7 @@ class Rakdeel(RakBaseModel):
         """Haalt een lijst van objecten (Paal of Kesp) op voor dit rakdeel op basis van de constructie naam."""
 
         rakdeel_id_lower = rakdeel_id.lower()
-        key = next((key for key in obj_dict.keys() if key.lower().startswith(rakdeel_id_lower)), None)
+        key = next((key for key in obj_dict.keys() if key.lower().startswith(rakdeel_id_lower)), "")
 
         return obj_dict.get(key, [])
 
@@ -160,7 +177,7 @@ class Rakdeel(RakBaseModel):
         constructieonderdeel_col = structured_table.get_column(header_in="Constructieonderdeel")
         aangetast_col = structured_table.get_column(header_in="Aangetast")
 
-        if not constructieonderdeel_col and not aangetast_col:
+        if not constructieonderdeel_col or not aangetast_col:
             logger.error("Could not find required columns in toestandsbepaling table")
             return dict_toestandsbepaling
 
@@ -181,7 +198,7 @@ class Rakdeel(RakBaseModel):
 
         return dict_toestandsbepaling
 
-    def assign_gebreken_to_children(self, gebreken: list[Gebrek]) -> None:
+    def add_gebreken(self, gebreken: list[Gebrek]) -> None:
         """Voeg gebreken toe aan het model. Indien mogelijk worden gebreken
         verdeeld over onderliggende componenten (kespen, palen, etc). Algemene
         gebreken worden opgeslagen in het Rakdeel model zelf.
@@ -192,54 +209,41 @@ class Rakdeel(RakBaseModel):
             Lijst van gebreken onttrokken uit de gebreken tabel in het duikrapport.
         """
 
-        niet_gevonden_kespen = 0
-        niet_gevonden_palen = 0
-
         for gebrek in gebreken:
-            gebrek_assigned = False
 
             # Try to extract kesp or paal id
             kesp_id = get_kesp_id(gebrek.codering)
             paal_id = get_paal_id(gebrek.codering)
 
-            # Match gebreken to onderdeel
+            # Match gebreken to o
             if isinstance(gebrek, (ScheurMetselwerk, LokaalVerdwenenMetselwerk)):
                 if self.bovenbouw.metselwerk is None:
                     self.bovenbouw.metselwerk = Metselwerk()
                 self.bovenbouw.metselwerk.gebreken.append(gebrek)
-                gebrek_assigned = True
 
             elif isinstance(gebrek, (GrondVoerendGat, BuikInWand)):
                 self.bovenbouw.gebreken.append(gebrek)
-                gebrek_assigned = True
 
             # Match kesp
             elif not kesp_id is None:
                 kesp = next((k for k in self.onderbouw.kespen if k.kesp_nummer == kesp_id), None)
                 if kesp:
                     kesp.gebreken.append(gebrek)
-                    gebrek_assigned = True
                 else:
-                    niet_gevonden_kespen += 1
+                    logger.warning(
+                        f"Kesp ID {kesp_id} gevonden in gebrek codering, maar geen overeenkomende Kesp in rakdeel {self.rakdeel_id}"
+                    )
 
             # Match paal
             elif not paal_id is None:
                 paal = next((p for p in self.onderbouw.palen if p.paal_nummer == paal_id), None)
                 if paal:
                     paal.gebreken.append(gebrek)
-                    gebrek_assigned = True
                 else:
-                    niet_gevonden_palen += 1
+                    logger.warning(
+                        f"Paal ID {paal_id} gevonden in gebrek codering, maar geen overeenkomende Paal in rakdeel {self.rakdeel_id}"
+                    )
 
-            if not gebrek_assigned:
+            else:
+                # If it doesnt belong to metselwerk, paal or kesp add to rakdeel itself
                 self.gebreken.append(gebrek)
-
-        if niet_gevonden_kespen:
-            logger.warning(
-                f"{niet_gevonden_kespen} kesp IDs gevonden in gebrek codering zonder overeenkomende kespen in rakdeel {self.rakdeel_id}"
-            )
-
-        if niet_gevonden_palen:
-            logger.warning(
-                f"{niet_gevonden_palen} paal IDs gevonden in gebrek codering zonder overeenkomende palen in rakdeel {self.rakdeel_id}"
-            )

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -67,23 +67,6 @@ class Rakdeel(RakBaseModel):
         """Return a string that uniquely identifies this Rakdeel instance."""
         return str(self.rakdeel_id)
 
-    # @property
-    # # TODO: Checken met geert of we dit wel willen implementeren, nu kan nog niet.
-    # def maximaal_aantal_scheuren_per_10_m(self) -> int | None:
-    #     """Aantal scheuren genormaliseerd naar 10 meter lengte."""
-    #     if self.lengte_m is None or self.lengte_m == 0:
-    #         return None
-    #     aantal_scheuren = self.bovenbouw.totaal_aantal_scheuren
-    #     return round((aantal_scheuren / self.lengte_m) * 10)
-
-    @property
-    def aantal_scheuren_per_meter(self) -> float | None:
-        """Scheur-dichtheid per meter."""
-        if self.lengte_m is None or self.lengte_m == 0:
-            return None
-        aantal_scheuren = self.bovenbouw.totaal_aantal_scheuren
-        return round(aantal_scheuren / self.lengte_m, 2)
-
     @classmethod
     async def from_smart_doc_section(
         cls, section: RakdeelSectie, kespen_dict: dict[str, list[Kesp]], palen_dict: dict[str, list[Paal]]
@@ -138,7 +121,7 @@ class Rakdeel(RakBaseModel):
         )
 
         # Add gebreken to rakdeel and subcomponents
-        rakdeel.add_gebreken(gebreken)
+        rakdeel.assign_gebreken_to_children(gebreken)
 
         return rakdeel
 
@@ -147,7 +130,7 @@ class Rakdeel(RakBaseModel):
         """Haalt een lijst van objecten (Paal of Kesp) op voor dit rakdeel op basis van de constructie naam."""
 
         rakdeel_id_lower = rakdeel_id.lower()
-        key = next((key for key in obj_dict.keys() if key.lower().startswith(rakdeel_id_lower)), "")
+        key = next((key for key in obj_dict.keys() if key.lower().startswith(rakdeel_id_lower)), None)
 
         return obj_dict.get(key, [])
 
@@ -177,7 +160,7 @@ class Rakdeel(RakBaseModel):
         constructieonderdeel_col = structured_table.get_column(header_in="Constructieonderdeel")
         aangetast_col = structured_table.get_column(header_in="Aangetast")
 
-        if not constructieonderdeel_col or not aangetast_col:
+        if not constructieonderdeel_col and not aangetast_col:
             logger.error("Could not find required columns in toestandsbepaling table")
             return dict_toestandsbepaling
 
@@ -198,7 +181,7 @@ class Rakdeel(RakBaseModel):
 
         return dict_toestandsbepaling
 
-    def add_gebreken(self, gebreken: list[Gebrek]) -> None:
+    def assign_gebreken_to_children(self, gebreken: list[Gebrek]) -> None:
         """Voeg gebreken toe aan het model. Indien mogelijk worden gebreken
         verdeeld over onderliggende componenten (kespen, palen, etc). Algemene
         gebreken worden opgeslagen in het Rakdeel model zelf.
@@ -209,41 +192,54 @@ class Rakdeel(RakBaseModel):
             Lijst van gebreken onttrokken uit de gebreken tabel in het duikrapport.
         """
 
+        niet_gevonden_kespen = 0
+        niet_gevonden_palen = 0
+
         for gebrek in gebreken:
+            gebrek_assigned = False
 
             # Try to extract kesp or paal id
             kesp_id = get_kesp_id(gebrek.codering)
             paal_id = get_paal_id(gebrek.codering)
 
-            # Match gebreken to o
+            # Match gebreken to onderdeel
             if isinstance(gebrek, (ScheurMetselwerk, LokaalVerdwenenMetselwerk)):
                 if self.bovenbouw.metselwerk is None:
                     self.bovenbouw.metselwerk = Metselwerk()
                 self.bovenbouw.metselwerk.gebreken.append(gebrek)
+                gebrek_assigned = True
 
             elif isinstance(gebrek, (GrondVoerendGat, BuikInWand)):
                 self.bovenbouw.gebreken.append(gebrek)
+                gebrek_assigned = True
 
             # Match kesp
             elif not kesp_id is None:
                 kesp = next((k for k in self.onderbouw.kespen if k.kesp_nummer == kesp_id), None)
                 if kesp:
                     kesp.gebreken.append(gebrek)
+                    gebrek_assigned = True
                 else:
-                    logger.warning(
-                        f"Kesp ID {kesp_id} gevonden in gebrek codering, maar geen overeenkomende Kesp in rakdeel {self.rakdeel_id}"
-                    )
+                    niet_gevonden_kespen += 1
 
             # Match paal
             elif not paal_id is None:
                 paal = next((p for p in self.onderbouw.palen if p.paal_nummer == paal_id), None)
                 if paal:
                     paal.gebreken.append(gebrek)
+                    gebrek_assigned = True
                 else:
-                    logger.warning(
-                        f"Paal ID {paal_id} gevonden in gebrek codering, maar geen overeenkomende Paal in rakdeel {self.rakdeel_id}"
-                    )
+                    niet_gevonden_palen += 1
 
-            else:
-                # If it doesnt belong to metselwerk, paal or kesp add to rakdeel itself
+            if not gebrek_assigned:
                 self.gebreken.append(gebrek)
+
+        if niet_gevonden_kespen:
+            logger.warning(
+                f"{niet_gevonden_kespen} kesp IDs gevonden in gebrek codering zonder overeenkomende kespen in rakdeel {self.rakdeel_id}"
+            )
+
+        if niet_gevonden_palen:
+            logger.warning(
+                f"{niet_gevonden_palen} paal IDs gevonden in gebrek codering zonder overeenkomende palen in rakdeel {self.rakdeel_id}"
+            )

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -121,7 +121,7 @@ class Rakdeel(RakBaseModel):
         )
 
         # Add gebreken to rakdeel and subcomponents
-        rakdeel.add_gebreken(gebreken)
+        rakdeel.assign_gebreken_to_children(gebreken)
 
         return rakdeel
 
@@ -181,7 +181,7 @@ class Rakdeel(RakBaseModel):
 
         return dict_toestandsbepaling
 
-    def add_gebreken(self, gebreken: list[Gebrek]) -> None:
+    def assign_gebreken_to_children(self, gebreken: list[Gebrek]) -> None:
         """Voeg gebreken toe aan het model. Indien mogelijk worden gebreken
         verdeeld over onderliggende componenten (kespen, palen, etc). Algemene
         gebreken worden opgeslagen in het Rakdeel model zelf.
@@ -193,25 +193,29 @@ class Rakdeel(RakBaseModel):
         """
 
         for gebrek in gebreken:
+            gebrek_assigned = False
 
             # Try to extract kesp or paal id
             kesp_id = get_kesp_id(gebrek.codering)
             paal_id = get_paal_id(gebrek.codering)
 
-            # Match gebreken to o
+            # Match gebreken to onderdeel
             if isinstance(gebrek, (ScheurMetselwerk, LokaalVerdwenenMetselwerk)):
                 if self.bovenbouw.metselwerk is None:
                     self.bovenbouw.metselwerk = Metselwerk()
                 self.bovenbouw.metselwerk.gebreken.append(gebrek)
+                gebrek_assigned = True
 
             elif isinstance(gebrek, (GrondVoerendGat, BuikInWand)):
                 self.bovenbouw.gebreken.append(gebrek)
+                gebrek_assigned = True
 
             # Match kesp
             elif not kesp_id is None:
                 kesp = next((k for k in self.onderbouw.kespen if k.kesp_nummer == kesp_id), None)
                 if kesp:
                     kesp.gebreken.append(gebrek)
+                    gebrek_assigned = True
                 else:
                     logger.warning(
                         f"Kesp ID {kesp_id} gevonden in gebrek codering, maar geen overeenkomende Kesp in rakdeel {self.rakdeel_id}"
@@ -222,11 +226,11 @@ class Rakdeel(RakBaseModel):
                 paal = next((p for p in self.onderbouw.palen if p.paal_nummer == paal_id), None)
                 if paal:
                     paal.gebreken.append(gebrek)
+                    gebrek_assigned = True
                 else:
                     logger.warning(
                         f"Paal ID {paal_id} gevonden in gebrek codering, maar geen overeenkomende Paal in rakdeel {self.rakdeel_id}"
                     )
 
-            else:
-                # If it doesnt belong to metselwerk, paal or kesp add to rakdeel itself
+            if not gebrek_assigned:
                 self.gebreken.append(gebrek)

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -160,7 +160,7 @@ class Rakdeel(RakBaseModel):
         constructieonderdeel_col = structured_table.get_column(header_in="Constructieonderdeel")
         aangetast_col = structured_table.get_column(header_in="Aangetast")
 
-        if not constructieonderdeel_col or not aangetast_col:
+        if not constructieonderdeel_col and not aangetast_col:
             logger.error("Could not find required columns in toestandsbepaling table")
             return dict_toestandsbepaling
 
@@ -192,6 +192,9 @@ class Rakdeel(RakBaseModel):
             Lijst van gebreken onttrokken uit de gebreken tabel in het duikrapport.
         """
 
+        niet_gevonden_kespen = 0
+        niet_gevonden_palen = 0
+
         for gebrek in gebreken:
             gebrek_assigned = False
 
@@ -217,9 +220,7 @@ class Rakdeel(RakBaseModel):
                     kesp.gebreken.append(gebrek)
                     gebrek_assigned = True
                 else:
-                    logger.warning(
-                        f"Kesp ID {kesp_id} gevonden in gebrek codering, maar geen overeenkomende Kesp in rakdeel {self.rakdeel_id}"
-                    )
+                    niet_gevonden_kespen += 1
 
             # Match paal
             elif not paal_id is None:
@@ -228,9 +229,17 @@ class Rakdeel(RakBaseModel):
                     paal.gebreken.append(gebrek)
                     gebrek_assigned = True
                 else:
-                    logger.warning(
-                        f"Paal ID {paal_id} gevonden in gebrek codering, maar geen overeenkomende Paal in rakdeel {self.rakdeel_id}"
-                    )
+                    niet_gevonden_palen += 1
 
             if not gebrek_assigned:
                 self.gebreken.append(gebrek)
+
+        if niet_gevonden_kespen:
+            logger.warning(
+                f"{niet_gevonden_kespen} kesp IDs gevonden in gebrek codering zonder overeenkomende kespen in rakdeel {self.rakdeel_id}"
+            )
+
+        if niet_gevonden_palen:
+            logger.warning(
+                f"{niet_gevonden_palen} paal IDs gevonden in gebrek codering zonder overeenkomende palen in rakdeel {self.rakdeel_id}"
+            )

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -130,7 +130,7 @@ class Rakdeel(RakBaseModel):
         """Haalt een lijst van objecten (Paal of Kesp) op voor dit rakdeel op basis van de constructie naam."""
 
         rakdeel_id_lower = rakdeel_id.lower()
-        key = next((key for key in obj_dict.keys() if key.lower().startswith(rakdeel_id_lower)), "")
+        key = next((key for key in obj_dict.keys() if key.lower().startswith(rakdeel_id_lower)), None)
 
         return obj_dict.get(key, [])
 


### PR DESCRIPTION
fixes #68 

- Checks for unassigned palen, kespen and houtmonsters after Rakdeel creation and puts them in separate lists in Rak
- Includes small fixes for table parsing