### PR TITLE
80 ken gebreken ook toe aan unassigned palenkespen

### DIFF
--- a/src/tekstherkenning_ark/models/kesp.py
+++ b/src/tekstherkenning_ark/models/kesp.py
@@ -143,7 +143,7 @@ class Kesp(RakBaseModel):
         )
 
         return cls(
-            kesp_nummer=table.get_value(header_in="Kespnummer", unit_in="[Ky]", index=row_idx),
+            kesp_nummer=utils.clean_kesp_id(table.get_value(header_in="Kespnummer", unit_in="[Ky]", index=row_idx)),
             hoogte_cm=table.get_value(header_in="Afmetingen", sub_header_in="Hoogte", unit_in="[cm]", index=row_idx),
             breedte_cm=table.get_value(header_in="Afmetingen", sub_header_in="Breedte", unit_in="[cm]", index=row_idx),
             hoek_tov_lengte_as_graden=table.get_value(

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -92,6 +92,7 @@ class Rakdeel(RakBaseModel):
 
         # Parse gebrekentabel
         gebreken = await Gebrek.from_doc_tables(section.gebreken_tabel)
+        overige_gebreken = cls.assign_gebreken_to_palen_kespen(gebreken, palen_dict, kespen_dict)
 
         # Verkrijg palen en kespen voor dit rakdeel
         palen = cls.get_for_constructie_naam(section.constructie_naam, palen_dict)
@@ -121,9 +122,54 @@ class Rakdeel(RakBaseModel):
         )
 
         # Add gebreken to rakdeel and subcomponents
-        rakdeel.assign_gebreken_to_children(gebreken)
+        rakdeel.assign_gebreken_to_children(overige_gebreken)
 
         return rakdeel
+
+    @staticmethod
+    def assign_gebreken_to_palen_kespen(
+        gebreken: list[Gebrek], palen_dict: dict[str, list[Paal]], kespen_dict: dict[str, list[Kesp]]
+    ) -> list[Gebrek]:
+        """Probeer gebreken toe te wijzen aan palen of kespen op basis van codering. Als dit niet lukt, worden ze teruggegeven als 'overige gebreken'."""
+        overige_gebreken = []
+
+        for gebrek in gebreken:
+
+            kesp = None
+            paal = None
+
+            # Probeer eerst aan kespen toe te wijzen
+            kesp_id = get_kesp_id(gebrek.codering)
+            if kesp_id:
+                for kesp_list in kespen_dict.values():
+                    kesp = next((k for k in kesp_list if k.kesp_nummer == kesp_id), None)
+                    if kesp:
+                        kesp.gebreken.append(gebrek)
+                        break
+                if not kesp:
+                    logger.warning(
+                        f"Gevonden kesp ID '{kesp_id}' in gebrek codering zonder overeenkomende kesp in rakdeel."
+                    )
+
+            # Probeer dan aan palen toe te wijzen
+            if not kesp:
+                paal_id = get_paal_id(gebrek.codering)
+                if paal_id:
+                    for paal_list in palen_dict.values():
+                        paal = next((p for p in paal_list if p.paal_nummer == paal_id), None)
+                        if paal:
+                            paal.gebreken.append(gebrek)
+                            break
+                    if not paal:
+                        logger.warning(
+                            f"Gevonden paal ID '{paal_id}' in gebrek codering zonder overeenkomende paal in rakdeel."
+                        )
+
+            # Als het gebrek niet is toegewezen, voeg het toe aan de overige gebreken
+            if paal is None and kesp is None:
+                overige_gebreken.append(gebrek)
+
+        return overige_gebreken
 
     @staticmethod
     def get_for_constructie_naam(rakdeel_id: str, obj_dict: dict[str, list[T]]) -> list[T]:

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -122,7 +122,7 @@ class Rakdeel(RakBaseModel):
         )
 
         # Add gebreken to rakdeel and subcomponents
-        rakdeel.assign_gebreken_to_children(overige_gebreken)
+        rakdeel.assign_overige_gebreken_to_children(overige_gebreken)
 
         return rakdeel
 
@@ -227,7 +227,7 @@ class Rakdeel(RakBaseModel):
 
         return dict_toestandsbepaling
 
-    def assign_gebreken_to_children(self, gebreken: list[Gebrek]) -> None:
+    def assign_overige_gebreken_to_children(self, gebreken: list[Gebrek]) -> None:
         """Voeg gebreken toe aan het model. Indien mogelijk worden gebreken
         verdeeld over onderliggende componenten (kespen, palen, etc). Algemene
         gebreken worden opgeslagen in het Rakdeel model zelf.
@@ -238,15 +238,8 @@ class Rakdeel(RakBaseModel):
             Lijst van gebreken onttrokken uit de gebreken tabel in het duikrapport.
         """
 
-        niet_gevonden_kespen = 0
-        niet_gevonden_palen = 0
-
         for gebrek in gebreken:
             gebrek_assigned = False
-
-            # Try to extract kesp or paal id
-            kesp_id = get_kesp_id(gebrek.codering)
-            paal_id = get_paal_id(gebrek.codering)
 
             # Match gebreken to onderdeel
             if isinstance(gebrek, (ScheurMetselwerk, LokaalVerdwenenMetselwerk)):
@@ -259,33 +252,5 @@ class Rakdeel(RakBaseModel):
                 self.bovenbouw.gebreken.append(gebrek)
                 gebrek_assigned = True
 
-            # Match kesp
-            elif not kesp_id is None:
-                kesp = next((k for k in self.onderbouw.kespen if k.kesp_nummer == kesp_id), None)
-                if kesp:
-                    kesp.gebreken.append(gebrek)
-                    gebrek_assigned = True
-                else:
-                    niet_gevonden_kespen += 1
-
-            # Match paal
-            elif not paal_id is None:
-                paal = next((p for p in self.onderbouw.palen if p.paal_nummer == paal_id), None)
-                if paal:
-                    paal.gebreken.append(gebrek)
-                    gebrek_assigned = True
-                else:
-                    niet_gevonden_palen += 1
-
             if not gebrek_assigned:
                 self.gebreken.append(gebrek)
-
-        if niet_gevonden_kespen:
-            logger.warning(
-                f"{niet_gevonden_kespen} kesp IDs gevonden in gebrek codering zonder overeenkomende kespen in rakdeel {self.rakdeel_id}"
-            )
-
-        if niet_gevonden_palen:
-            logger.warning(
-                f"{niet_gevonden_palen} paal IDs gevonden in gebrek codering zonder overeenkomende palen in rakdeel {self.rakdeel_id}"
-            )

--- a/src/tekstherkenning_ark/utils.py
+++ b/src/tekstherkenning_ark/utils.py
@@ -9,6 +9,8 @@ from tekstherkenning_ark.enums import NietBeschikbaar
 
 from typing import TYPE_CHECKING, Callable
 
+from tekstherkenning_ark.logger import get_logger
+
 if TYPE_CHECKING:
     from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
 
@@ -18,6 +20,8 @@ KESP_ID_PATTERN = r"\bK\d+\b"
 RAK_ID_PATTERN = r"([A-Z]{3}\d{4})(-\d{2})?"
 CONSTRUCTIE_PATTERN = r"constructie [a-z]"
 ALGEMEEN_GEBREK_PATTERN = r"^GB\d{1,3}$"
+
+logger = get_logger(__name__)
 
 
 def get_table_content(table: DocumentTable) -> list[list[str]]:
@@ -75,8 +79,8 @@ def clean_paal_id(value: str) -> str:
     """Correct for common errors in paal ID's.
 
     Known and accepted exceptions:
-    - P.2.163
-    - 21.169
+    - P.2.163 -> P2.163
+    - 21.169 -> P2.169
     """
 
     value = clean_string(value)
@@ -89,18 +93,44 @@ def clean_paal_id(value: str) -> str:
     return exceptions_dict.get(value, value)
 
 
+def clean_kesp_id(value: str) -> str:
+    """Correct for common errors in kesp ID's.
+
+    Known and accepted exceptions:
+    - Kg -> K9
+    """
+
+    value = clean_string(value)
+
+    exceptions_dict = {
+        "Kg": "K9",
+    }
+
+    return exceptions_dict.get(value, value)
+
+
 def contains_paal_id(value: str) -> bool:
     r"""Check if a string contains the pattern 'P\d.\d+' (e.g., P1.1, P2.10)"""
 
     value = clean_paal_id(clean_string(value))
+    found = bool(re.search(PAAL_ID_PATTERN, value))
 
-    return bool(re.search(PAAL_ID_PATTERN, value.strip()))
+    if not found and value.strip().lower().startswith("p"):
+        logger.warning(f"Waarschijnlijk paal ID gevonden dat niet voldoet aan patroon: '{value}'")
+
+    return found
 
 
 def contains_kesp_id(value: str) -> bool:
     r"""Check if a string contains the pattern 'K\d+' (e.g., K1, K24)"""
 
-    return bool(re.search(KESP_ID_PATTERN, value.strip()))
+    value = clean_kesp_id(clean_string(value))
+    found = bool(re.search(KESP_ID_PATTERN, value))
+
+    if not found and value.strip().lower().startswith("k"):
+        logger.warning(f"Waarschijnlijk kesp ID gevonden dat niet voldoet aan patroon: '{value}'")
+
+    return found
 
 
 def get_paal_id(value: str) -> str | None:
@@ -116,9 +146,9 @@ def get_paal_id(value: str) -> str | None:
     str | None
         The extracted paal ID or None if not found
     """
-    value = clean_paal_id(clean_string(value))
 
-    match = re.search(PAAL_ID_PATTERN, value.strip())
+    value = clean_paal_id(clean_string(value))
+    match = re.search(PAAL_ID_PATTERN, value)
 
     return match.group(0) if match else None
 
@@ -136,9 +166,9 @@ def get_kesp_id(value: str) -> str | None:
     str | None
         The extracted kesp ID or None if not found
     """
-    value = clean_string(value)
 
-    match = re.search(KESP_ID_PATTERN, value.strip())
+    value = clean_kesp_id(clean_string(value))
+    match = re.search(KESP_ID_PATTERN, value)
 
     return match.group(0) if match else None
 


### PR DESCRIPTION
fixes #80 

- Assign rakdeel gebreken to `palen_dict` and `kespen_dict` instead of just the rakdeel palen en kespen, which allows gebreken to be assigned to palen and kespen that don't have a rakdeel
- Includes small fix for kesp ID parsing and logging

Review AFTER #79 is merged to develop