### PR TITLE
fix onderloopsheidscherm en toevoegen vervormde kespen

### DIFF
--- a/scripts/vergelijk_testset_met_parsing.py
+++ b/scripts/vergelijk_testset_met_parsing.py
@@ -411,7 +411,7 @@ def vergelijk_rakdeel(
         "onderbouw.materiaal_fundering": "onderbouw.materiaal_fundering",
         "onderbouw.materiaal_onderbouw": "onderbouw.materiaal",
         "onderbouw.vloer.is_beschadigd": "onderbouw.vloer.is_beschadigd",
-        "onderbouw.onderloopsheidscherm.is_aanwezig": "onderbouw.onderloopsheidscherm.is_beschadigd",
+        "onderbouw.onderloopsheidscherm.is_aanwezig": "onderbouw.onderloopsheidscherm",
         "onderbouw.onderloopsheidscherm.is_beschadigd": "onderbouw.onderloopsheidscherm.is_beschadigd",
         "vloer.bovenkant_vloer_cm_tov_nap": "onderbouw.vloer.bovenkant_vloer_cm_tov_nap",
         "lengte_rakdeel_m": "lengte_m",
@@ -450,7 +450,14 @@ def vergelijk_rakdeel(
         except Exception:
             pass
 
-        # Bepaal of waarden overeen komen
+        # Als het verwachte type bool is en de waarde een object is (geen scalair),
+        # reduceer dan naar True/False op basis van aanwezigheid (niet-None = True)
+        if (
+            mapping.datatype == bool
+            and gekregen_waarde is not None
+            and not isinstance(gekregen_waarde, (bool, int, float, str))
+        ):
+            gekregen_waarde = True
         is_correct: bool | None = None
         verwacht_missing = pd.isna(verwachte_waarde) or verwachte_waarde is None
         gekregen_missing = gekregen_waarde is None or pd.isna(gekregen_waarde)
@@ -663,36 +670,42 @@ def main():
 
     print("\nStap 2: Vergelijken rakken...")
     for rak_id in unieke_rak_ids:
-        print(f"\n  Verwerken: {rak_id}")
+        if rak_id == "OVW0401":  # Voorbeeld van een RAK ID die mogelijk problemen geeft
+            print(f"\n  Verwerken: {rak_id}")
 
-        # Laad gecachte Rak
-        rak = laad_gecachte_rak(rak_id)
-        if rak is None:
-            print(f"    ⚠️  Geen gecachte Rak gevonden - overslaan")
-            continue
+            # Laad gecachte Rak
+            rak = laad_gecachte_rak(rak_id)
+            if rak is None:
+                print(f"    ⚠️  Geen gecachte Rak gevonden - overslaan")
+                continue
 
-        print(f"    ✓ Gecachte Rak geladen ({len(rak.rakdelen)} rakdelen)")
+            print(f"    ✓ Gecachte Rak geladen ({len(rak.rakdelen)} rakdelen)")
 
-        # Filter testset rijen voor deze RAK
-        testset_rijen = df_testset[df_testset["rak_id"] == rak_id]
+            # Filter testset rijen voor deze RAK
+            testset_rijen = df_testset[df_testset["rak_id"] == rak_id]
 
-        # Vergelijk elk rakdeel
-        all_ids = list(testset_rijen["rakdeel_id"])
-        for idx, (_, rij) in enumerate(testset_rijen.iterrows()):
-            rakdeel_id = rij["rakdeel_id"]
-            print(f"      - Vergelijken rakdeel: {rakdeel_id}")
+            # Vergelijk elk rakdeel
+            all_ids = list(testset_rijen["rakdeel_id"])
+            for idx, (_, rij) in enumerate(testset_rijen.iterrows()):
+                rakdeel_id = rij["rakdeel_id"]
+                print(f"      - Vergelijken rakdeel: {rakdeel_id}")
 
-            vergelijking = vergelijk_rakdeel(
-                rij, rak, rakdeel_id, ARK_KOLOM_MAPPINGS, testset_rakdeel_index=idx, all_testset_rakdeel_ids=all_ids
-            )
-            if vergelijking:
-                statistieken.rakdeel_vergelijkingen.append(vergelijking)
-                print(
-                    f"        Resultaat: {vergelijking.aantal_correct} correct, "
-                    f"{vergelijking.aantal_fout} fout, "
-                    f"{vergelijking.aantal_ontbrekend} ontbrekend "
-                    f"({vergelijking.accuratie_percentage}% accuratie)"
+                vergelijking = vergelijk_rakdeel(
+                    rij,
+                    rak,
+                    rakdeel_id,
+                    ARK_KOLOM_MAPPINGS,
+                    testset_rakdeel_index=idx,
+                    all_testset_rakdeel_ids=all_ids,
                 )
+                if vergelijking:
+                    statistieken.rakdeel_vergelijkingen.append(vergelijking)
+                    print(
+                        f"        Resultaat: {vergelijking.aantal_correct} correct, "
+                        f"{vergelijking.aantal_fout} fout, "
+                        f"{vergelijking.aantal_ontbrekend} ontbrekend "
+                        f"({vergelijking.accuratie_percentage}% accuratie)"
+                    )
 
     # Print samenvatting
     print("\n" + "=" * 80)

--- a/src/tekstherkenning_ark/llm/rakdeel_omschrijving.py
+++ b/src/tekstherkenning_ark/llm/rakdeel_omschrijving.py
@@ -83,7 +83,7 @@ class RakdeelOmschrijving(LLMClassifier):
     # onderloopsheidscherm aanwezig ja/nee
     onderloopsheidscherm: bool | NietBeschikbaar = Field(
         default=NietBeschikbaar.LEEG,
-        description="Geef aan of er een onderloopsheidscherm aanwezig is bij dit rakdeel door middel van boolean.",
+        description="Geef aan of er een onderloopsheidscherm aanwezig is bij dit rakdeel door middel van boolean. Herkenbaar aan woorden zoals 'grondkerend scherm', 'onderloopsheidscherm', 'scherm' in de omschrijving.",
     )
 
     # benodigd voor constructie waterbodem

--- a/src/tekstherkenning_ark/models/onderbouw.py
+++ b/src/tekstherkenning_ark/models/onderbouw.py
@@ -100,13 +100,21 @@ class Onderbouw(RakBaseModel):
 
     @property
     def percentage_beschadigde_kespen(self) -> float | None:
-        # TODO: Checken met Geert hoe een beschadigde kesp gedefinieerd is en of dit veld in de meettabel kespen staat.
         """Percentage kespen met vervorming of aantasting."""
         if not self.kespen:
             return None
 
         aantal_beschadigd = sum(1 for kesp in self.kespen if kesp.is_vervormd or kesp.is_aangetast)
         return round((aantal_beschadigd / len(self.kespen)) * 100, 2)
+
+    @property
+    def percentage_vervormde_kespen(self) -> float | None:
+        """Percentage kespen met vervorming."""
+        if not self.kespen:
+            return None
+
+        aantal_vervormd = sum(1 for kesp in self.kespen if kesp.is_vervormd)
+        return round((aantal_vervormd / len(self.kespen)) * 100, 2)
 
     @property
     def percentage_beschadigde_verbinding(self) -> float | None:

--- a/src/tekstherkenning_ark/models/onderloopsheidscherm.py
+++ b/src/tekstherkenning_ark/models/onderloopsheidscherm.py
@@ -26,7 +26,7 @@ class Onderloopsheidscherm(RakBaseModel):
     @property
     def is_beschadigd(self) -> bool:
         heeft_gebrek = bool(self.gebreken)
-        is_beschadigd = any(toestand for toestand in self.toestand_onderdelen)
+        is_beschadigd = any(toestand.aangetast for toestand in self.toestand_onderdelen)
         return heeft_gebrek or is_beschadigd
 
     @property

--- a/src/tekstherkenning_ark/models/onderloopsheidscherm.py
+++ b/src/tekstherkenning_ark/models/onderloopsheidscherm.py
@@ -45,7 +45,7 @@ class Onderloopsheidscherm(RakBaseModel):
             Onderloopsheidscherm | None: Een leeg Onderloopsheidscherm model, of None als er geen onderloopsheidscherm is.
         """
 
-        if not omschrijving.onderloopsheidscherm:
+        if omschrijving.onderloopsheidscherm:
             return cls()
 
         return None

--- a/tests/test_onderloopsheidscherm.py
+++ b/tests/test_onderloopsheidscherm.py
@@ -1,0 +1,127 @@
+"""Tests voor het Onderloopsheidscherm model."""
+
+from unittest.mock import MagicMock
+
+from tekstherkenning_ark.models.onderloopsheidscherm import Onderloopsheidscherm
+from tekstherkenning_ark.models.toestand_onderdeel import ToestandOnderdeel
+from tekstherkenning_ark.models.gebrek import Gebrek
+from tekstherkenning_ark.enums import NietBeschikbaar
+
+
+# ==============================================================================
+# Hulpfuncties
+# ==============================================================================
+
+
+def maak_mock_omschrijving(onderloopsheidscherm: bool | NietBeschikbaar) -> MagicMock:
+    """Maak een mock RakdeelOmschrijving met het opgegeven onderloopsheidscherm veld.
+
+    Parameters
+    ----------
+    onderloopsheidscherm : bool | NietBeschikbaar
+        Waarde voor het onderloopsheidscherm veld.
+    """
+    mock = MagicMock()
+    mock.onderloopsheidscherm = onderloopsheidscherm
+    return mock
+
+
+def maak_toestand_onderdeel(aangetast: bool) -> ToestandOnderdeel:
+    """Maak een ToestandOnderdeel voor een onderloopsheidscherm.
+
+    Parameters
+    ----------
+    aangetast : bool
+        Indicatie of het onderdeel aangetast is.
+    """
+    return ToestandOnderdeel(
+        constructie_onderdeel="onderloopsheidscherm",
+        aangetast=aangetast,
+    )
+
+
+# ==============================================================================
+# Tests voor from_rakdeel_omschrijving
+# ==============================================================================
+
+
+class TestFromRakdeelOmschrijving:
+    """Tests voor Onderloopsheidscherm.from_rakdeel_omschrijving."""
+
+    def test_onderloopsheidscherm_aanwezig(self):
+        """Test dat een Onderloopsheidscherm wordt aangemaakt als het in de omschrijving voorkomt."""
+        omschrijving = maak_mock_omschrijving(onderloopsheidscherm=True)
+
+        result = Onderloopsheidscherm.from_rakdeel_omschrijving(omschrijving)
+
+        assert isinstance(result, Onderloopsheidscherm)
+
+    def test_onderloopsheidscherm_afwezig(self):
+        """Test dat None wordt teruggegeven als het onderloopsheidscherm niet in de omschrijving voorkomt."""
+        omschrijving = maak_mock_omschrijving(onderloopsheidscherm=False)
+
+        result = Onderloopsheidscherm.from_rakdeel_omschrijving(omschrijving)
+
+        assert result is None
+
+    def test_onderloopsheidscherm_niet_beschikbaar(self):
+        """Test dat None wordt teruggegeven als het onderloopsheidscherm niet beschikbaar is."""
+        omschrijving = maak_mock_omschrijving(onderloopsheidscherm=NietBeschikbaar.LEEG)
+
+        result = Onderloopsheidscherm.from_rakdeel_omschrijving(omschrijving)
+
+        assert result is None
+
+    def test_nieuw_object_heeft_lege_defaults(self):
+        """Test dat het aangemaakte object lege standaardwaarden heeft."""
+        omschrijving = maak_mock_omschrijving(onderloopsheidscherm=True)
+
+        result = Onderloopsheidscherm.from_rakdeel_omschrijving(omschrijving)
+
+        assert result.gebreken == []
+        assert result.toestand_onderdelen == []
+        assert result.is_meerdere_locaties is None
+
+
+# ==============================================================================
+# Tests voor is_beschadigd
+# ==============================================================================
+
+
+class TestIsBeschadigd:
+    """Tests voor de is_beschadigd property van Onderloopsheidscherm."""
+
+    def test_niet_beschadigd_zonder_gebreken_en_toestand(self):
+        """Test dat is_beschadigd False is als er geen gebreken en geen toestand_onderdelen zijn."""
+        scherm = Onderloopsheidscherm()
+
+        assert scherm.is_beschadigd is False
+
+    def test_beschadigd_met_gebrek(self):
+        """Test dat is_beschadigd True is als er een gebrek aanwezig is."""
+        scherm = Onderloopsheidscherm(
+            gebreken=[Gebrek(codering="GS1", omschrijving="Schade aan scherm", figuurnummer="F1")]
+        )
+
+        assert scherm.is_beschadigd is True
+
+    def test_beschadigd_met_aangetast_toestand_onderdeel(self):
+        """Test dat is_beschadigd True is als er een aangetast toestand_onderdeel aanwezig is."""
+        scherm = Onderloopsheidscherm(toestand_onderdelen=[maak_toestand_onderdeel(aangetast=True)])
+
+        assert scherm.is_beschadigd is True
+
+    def test_niet_beschadigd_met_niet_aangetast_toestand_onderdeel(self):
+        """Test dat is_beschadigd False is als het toestand_onderdeel niet aangetast is."""
+        scherm = Onderloopsheidscherm(toestand_onderdelen=[maak_toestand_onderdeel(aangetast=False)])
+
+        assert scherm.is_beschadigd is False
+
+    def test_beschadigd_met_zowel_gebrek_als_toestand(self):
+        """Test dat is_beschadigd True is als zowel gebreken als toestand_onderdelen aanwezig zijn."""
+        scherm = Onderloopsheidscherm(
+            gebreken=[Gebrek(codering="GS1", omschrijving="Schade aan scherm", figuurnummer="F1")],
+            toestand_onderdelen=[maak_toestand_onderdeel(aangetast=True)],
+        )
+
+        assert scherm.is_beschadigd is True


### PR DESCRIPTION
fixes #114
related #113

voor #113
- percentage vervormde kespen toegevoegd

voor #114
`scripts/vergelijking_testset_met_parsing.py`:
- Fix dat ook op entity gecheckt kan worden

`Onderloopsheidscherm`:
- bug fix bij classmethod voor instantieren (boolean omgedraaid en getest)
- is_beschadigd aangepast dat het checkt op waarde toestandsbepaling

`RakdeelOmschrijving`:
- Verruiming in prompt voor vinden onderloopsheidscherm