### PR TITLE
add extra properties

### DIFF
--- a/src/tekstherkenning_ark/models/onderbouw.py
+++ b/src/tekstherkenning_ark/models/onderbouw.py
@@ -181,7 +181,7 @@ class Onderbouw(RakBaseModel):
     def aantal_ongewenst_schoor(self) -> int:
         """Aantal palen met geconstateerde negatieve schoorstand."""
 
-        return sum(paal.is_ongewenste_schoorstand and paal.paalrij_nummer == 1 for paal in self.palen)
+        return sum((paal.is_ongewenste_schoorstand or 0) and paal.paalrij_nummer == 1 for paal in self.palen)
 
     @computed_field
     @property
@@ -227,7 +227,7 @@ class Onderbouw(RakBaseModel):
     @property
     def aantal_beschadigde_kespen(self) -> int:
         """Aantal kespen met vervorming of aantasting."""
-        return sum(kesp.is_vervormd or kesp.is_aangetast for kesp in self.kespen)
+        return sum((kesp.is_vervormd or 0) or (kesp.is_aangetast or 0) for kesp in self.kespen)
 
     @computed_field
     @property

--- a/src/tekstherkenning_ark/models/onderbouw.py
+++ b/src/tekstherkenning_ark/models/onderbouw.py
@@ -44,13 +44,13 @@ class Onderbouw(RakBaseModel):
         """Return a string that uniquely identifies this Onderbouw instance."""
         return "onderbouw"
 
-    @computed_field  # TODO
+    @computed_field
     @property
     def aantal_paalrijen(self) -> int:
         """Aantal paalrijen in de onderbouw (unieke paalrij_nummer waarden)."""
         return len(set(paal.paalrij_nummer for paal in self.palen))
 
-    @computed_field  # TODO
+    @computed_field
     @property
     def aantal_palen_per_rij(self) -> dict[int, int]:
         """Aantal palen per paalrij in de onderbouw.
@@ -60,17 +60,13 @@ class Onderbouw(RakBaseModel):
         dict[int, int]
             Dictionary waarbij de keys de paalrij_nummer zijn en de values het aantal palen in die rij.
         """
+        return {rij_nummer: len(palen) for rij_nummer, palen in self.paal_rijen.items()}
 
-        # TODO is rijnummer P1.12 `1`` of `12`?
-
-        rijen = self.paal_rijen
-        return {rij_nummer: len(palen) for rij_nummer, palen in rijen.items()}
-
-    @computed_field  # TODO
+    @computed_field
     @property
     def aantal_rijen_onderzocht(self) -> int:
         """Aantal onderzochte paalrijen in de onderbouw."""
-        return len(self.paal_rijen)
+        return {rij_nummer: any(paal.is_onderzocht for paal in palen) for rij_nummer, palen in self.paal_rijen.items()}
 
     @computed_field
     @property
@@ -78,19 +74,21 @@ class Onderbouw(RakBaseModel):
         """Aantal paalrijen in dwarsdoorsneden (maximale paalrij_nummer waarde)."""
         if not self.palen:
             return 0
-        return max(paal.paalrij_nummer for paal in self.palen)
+        return max(paal.paalrij_nummer if isinstance(paal.paalrij_nummer, (int, float)) else 0 for paal in self.palen)
 
-    @computed_field  # TODO is een aansluiting altijd aanwezig, of alleen als de aansluitingstatus slecht of goed is?
+    @computed_field
     @property
     def aantal_aansluitingen(self) -> int:
         """Totaal aantal aansluitingen tussen palen en kespen in de onderbouw."""
-        return sum(paal.aansluiting_status is not None for paal in self.palen)
+        return sum(
+            paal.aansluiting_status in [AansluitingStatus.GOED, AansluitingStatus.SLECHT] for paal in self.palen
+        )
 
     @computed_field
     @property
     def aantal_slechte_aansluitingen(self) -> int:
         """Totaal aantal slechte aansluitingen tussen palen en kespen in de onderbouw."""
-        return sum(paal.aansluiting_status == AansluitingStatus.SLECHT for paal in self.palen)
+        return sum(paal.aansluiting_status is AansluitingStatus.SLECHT for paal in self.palen)
 
     @computed_field
     @property

--- a/src/tekstherkenning_ark/models/onderbouw.py
+++ b/src/tekstherkenning_ark/models/onderbouw.py
@@ -66,7 +66,7 @@ class Onderbouw(RakBaseModel):
     @property
     def aantal_rijen_onderzocht(self) -> int:
         """Aantal onderzochte paalrijen in de onderbouw."""
-        return {rij_nummer: any(paal.is_onderzocht for paal in palen) for rij_nummer, palen in self.paal_rijen.items()}
+        return sum([any(paal.is_onderzocht for paal in palen) for palen in self.paal_rijen.values()])
 
     @computed_field
     @property

--- a/src/tekstherkenning_ark/models/onderbouw.py
+++ b/src/tekstherkenning_ark/models/onderbouw.py
@@ -44,6 +44,34 @@ class Onderbouw(RakBaseModel):
         """Return a string that uniquely identifies this Onderbouw instance."""
         return "onderbouw"
 
+    @computed_field  # TODO
+    @property
+    def aantal_paalrijen(self) -> int:
+        """Aantal paalrijen in de onderbouw (unieke paalrij_nummer waarden)."""
+        return len(set(paal.paalrij_nummer for paal in self.palen))
+
+    @computed_field  # TODO
+    @property
+    def aantal_palen_per_rij(self) -> dict[int, int]:
+        """Aantal palen per paalrij in de onderbouw.
+
+        Returns
+        -------
+        dict[int, int]
+            Dictionary waarbij de keys de paalrij_nummer zijn en de values het aantal palen in die rij.
+        """
+
+        # TODO is rijnummer P1.12 `1`` of `12`?
+
+        rijen = self.paal_rijen
+        return {rij_nummer: len(palen) for rij_nummer, palen in rijen.items()}
+
+    @computed_field  # TODO
+    @property
+    def aantal_rijen_onderzocht(self) -> int:
+        """Aantal onderzochte paalrijen in de onderbouw."""
+        return len(self.paal_rijen)
+
     @computed_field
     @property
     def aantal_palen_dwars(self) -> int:
@@ -51,6 +79,18 @@ class Onderbouw(RakBaseModel):
         if not self.palen:
             return 0
         return max(paal.paalrij_nummer for paal in self.palen)
+
+    @computed_field  # TODO is een aansluiting altijd aanwezig, of alleen als de aansluitingstatus slecht of goed is?
+    @property
+    def aantal_aansluitingen(self) -> int:
+        """Totaal aantal aansluitingen tussen palen en kespen in de onderbouw."""
+        return sum(paal.aansluiting_status is not None for paal in self.palen)
+
+    @computed_field
+    @property
+    def aantal_slechte_aansluitingen(self) -> int:
+        """Totaal aantal slechte aansluitingen tussen palen en kespen in de onderbouw."""
+        return sum(paal.aansluiting_status == AansluitingStatus.SLECHT for paal in self.palen)
 
     @computed_field
     @property
@@ -140,13 +180,19 @@ class Onderbouw(RakBaseModel):
 
     @computed_field
     @property
+    def aantal_ongewenst_schoor(self) -> int:
+        """Aantal palen met geconstateerde negatieve schoorstand."""
+
+        return sum(paal.is_ongewenste_schoorstand and paal.paalrij_nummer == 1 for paal in self.palen)
+
+    @computed_field
+    @property
     def percentage_ongewenste_schoorstand(self) -> float | None:
         """Percentage palen met ongewenste/afwijkende schoorstand."""
         if not self.palen:
             return None
 
-        aantal_ongewenst = sum(1 for paal in self.palen if paal.is_ongewenste_schoorstand and paal.paalrij_nummer == 1)
-        return round((aantal_ongewenst / len(self.palen)) * 100, 2)
+        return round((self.aantal_ongewenst_schoor / len(self.palen)) * 100, 2)
 
     @computed_field
     @property
@@ -181,13 +227,18 @@ class Onderbouw(RakBaseModel):
 
     @computed_field
     @property
+    def aantal_beschadigde_kespen(self) -> int:
+        """Aantal kespen met vervorming of aantasting."""
+        return sum(kesp.is_vervormd or kesp.is_aangetast for kesp in self.kespen)
+
+    @computed_field
+    @property
     def percentage_beschadigde_kespen(self) -> float | None:
         """Percentage kespen met vervorming of aantasting."""
         if not self.kespen:
             return None
 
-        aantal_beschadigd = sum(1 for kesp in self.kespen if kesp.is_vervormd or kesp.is_aangetast)
-        return round((aantal_beschadigd / len(self.kespen)) * 100, 2)
+        return round((self.aantal_beschadigde_kespen / len(self.kespen)) * 100, 2)
 
     @computed_field
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from tekstherkenning_ark.document.smart_document import SmartDocument
 from tekstherkenning_ark import constants
 from pathlib import Path
 
+from tekstherkenning_ark.models.onderbouw import Onderbouw
 from tekstherkenning_ark.models.paal import Paal
 from tekstherkenning_ark.models.rak import Rak
 from tekstherkenning_ark.models.rakdeel import Rakdeel
@@ -96,6 +97,12 @@ def mock_rak_with_scheuren() -> Rak:
 def mock_rakdeel(mock_rak_with_gebreken: Rak) -> Rakdeel:
     """Fixture to provide a single Rakdeel from the mock Rak with gebreken."""
     return mock_rak_with_gebreken.rakdelen[0]
+
+
+@pytest.fixture()
+def mock_onderbouw(mock_rakdeel: Rakdeel) -> Onderbouw:
+    """Fixture to provide the Onderbouw from the mock Rakdeel with gebreken."""
+    return mock_rakdeel.onderbouw
 
 
 @pytest.fixture()

--- a/tests/data/mock_rak_with_gebreken.py
+++ b/tests/data/mock_rak_with_gebreken.py
@@ -52,6 +52,7 @@ def create_mock_rak_with_gebreken() -> Rak:
                             is_aantasting=False,
                             aansluiting_status="G",
                             positionering_aansluiting_cm="0",
+                            is_onderzocht=True,
                             gebreken=[
                                 Gebrek(
                                     codering="GP1",
@@ -75,6 +76,7 @@ def create_mock_rak_with_gebreken() -> Rak:
                             is_aantasting=False,
                             aansluiting_status="G",
                             positionering_aansluiting_cm="0",
+                            is_onderzocht=False,
                         ),
                         Paal(
                             paal_nummer="P2.2",
@@ -91,6 +93,7 @@ def create_mock_rak_with_gebreken() -> Rak:
                             is_aantasting=False,
                             aansluiting_status="G",
                             positionering_aansluiting_cm="0",
+                            is_onderzocht=True,
                         ),
                         Paal(
                             paal_nummer="P1.3",
@@ -107,6 +110,7 @@ def create_mock_rak_with_gebreken() -> Rak:
                             is_aantasting=False,
                             aansluiting_status="G",
                             positionering_aansluiting_cm="0",
+                            is_onderzocht=True,
                         ),
                     ],
                     kespen=[

--- a/tests/test_onderbouw.py
+++ b/tests/test_onderbouw.py
@@ -459,3 +459,227 @@ def test_get_consecutive_palen_no_hoh_afstand_cm(mock_rakdeel: Rakdeel):
     assert isinstance(result, OnverwachtResultaat)
     assert result.onverwacht_resultaat_type == OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT
     assert "Ontbrekende hoh_afstand_cm voor paal" in result.details
+
+
+def test_aantal_paalrijen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_paalrijen het aantal unieke paalrijen teruggeeft."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Mock data heeft palen in rij 1 (P1.1, P1.2, P1.3) en rij 2 (P2.2)
+    assert onderbouw.aantal_paalrijen == 2
+
+
+def test_aantal_paalrijen_geen_palen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_paalrijen 0 is als er geen palen zijn."""
+    mock_rakdeel.onderbouw.palen = []
+
+    assert mock_rakdeel.onderbouw.aantal_paalrijen == 0
+
+
+def test_aantal_palen_per_rij(mock_rakdeel: Rakdeel):
+    """Test dat aantal_palen_per_rij een correct overzicht geeft van palen per rij."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Mock data heeft 3 palen in rij 1 en 1 paal in rij 2
+    assert onderbouw.aantal_palen_per_rij == {1: 3, 2: 1}
+
+
+def test_aantal_palen_per_rij_extra_paal(mock_rakdeel: Rakdeel, maak_paal_rij_1):
+    """Test dat aantal_palen_per_rij correct update bij het toevoegen van palen."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Voeg extra paal toe aan rij 1
+    extra_paal = maak_paal_rij_1("P1.4", AansluitingStatus.GOED)
+    onderbouw.palen.append(extra_paal)
+
+    assert onderbouw.aantal_palen_per_rij == {1: 4, 2: 1}
+
+
+def test_aantal_palen_per_rij_meerdere_rijen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_palen_per_rij correct werkt met meerdere paalrijen."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Voeg palen toe aan een derde rij
+    paal_rij_3_1 = Paal(
+        paal_nummer="P3.1",
+        paalrij_nummer=3,
+        hoh_paalnummer="",
+        diameter_haaks=150,
+        diameter_parallel=150,
+        diameter_gemiddeld=150,
+        hoh_afstand_cm=100,
+        schoor_graden=5,
+        schoor_richting="PNV",
+        afstand_frontwand_cm=25,
+        is_scheefstand=False,
+        is_paalbreuk=False,
+        is_aantasting=False,
+        aansluiting_status=AansluitingStatus.GOED,
+        positionering_aansluiting_cm="0",
+    )
+    paal_rij_3_2 = Paal(
+        paal_nummer="P3.2",
+        paalrij_nummer=3,
+        hoh_paalnummer="P3.1",
+        diameter_haaks=150,
+        diameter_parallel=150,
+        diameter_gemiddeld=150,
+        hoh_afstand_cm=100,
+        schoor_graden=5,
+        schoor_richting="PNV",
+        afstand_frontwand_cm=25,
+        is_scheefstand=False,
+        is_paalbreuk=False,
+        is_aantasting=False,
+        aansluiting_status=AansluitingStatus.GOED,
+        positionering_aansluiting_cm="0",
+    )
+    onderbouw.palen.extend([paal_rij_3_1, paal_rij_3_2])
+
+    assert onderbouw.aantal_palen_per_rij == {1: 3, 2: 1, 3: 2}
+
+
+def test_aantal_ongewenst_schoor(mock_rakdeel: Rakdeel):
+    """Test dat aantal_ongewenst_schoor alleen eerste-rij palen met negatieve schoorstand telt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Alle palen hebben standaard PNV (positief), dus aantal_ongewenst_schoor moet 0 zijn
+    assert onderbouw.aantal_ongewenst_schoor == 0
+
+
+def test_aantal_ongewenst_schoor_een_paal(mock_rakdeel: Rakdeel):
+    """Test dat aantal_ongewenst_schoor correct telt bij één paal met ongewenste schoorstand."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet P1.1 (eerste rij) op negatieve schoorstand
+    p1_1 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P1.1")
+    p1_1.schoor_richting = SchoorStand.NEGATIEF
+
+    assert onderbouw.aantal_ongewenst_schoor == 1
+
+
+def test_aantal_ongewenst_schoor_meerdere_palen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_ongewenst_schoor correct telt bij meerdere palen met ongewenste schoorstand."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet alle eerste-rij palen op negatieve schoorstand
+    for paal in onderbouw.palen:
+        if paal.paalrij_nummer == 1:
+            paal.schoor_richting = SchoorStand.NEGATIEF
+
+    assert onderbouw.aantal_ongewenst_schoor == 3
+
+
+def test_aantal_ongewenst_schoor_tweede_rij_telt_niet_mee(mock_rakdeel: Rakdeel):
+    """Test dat aantal_ongewenst_schoor alleen eerste-rij palen meetelt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet alleen P2.2 (tweede rij) op negatieve schoorstand
+    p2_2 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P2.2")
+    p2_2.schoor_richting = SchoorStand.NEGATIEF
+
+    # Tweede-rij palen meetellen niet
+    assert onderbouw.aantal_ongewenst_schoor == 0
+
+
+def test_totaal_aantal_kespen(mock_rakdeel: Rakdeel):
+    """Test dat totaal_aantal_kespen het juiste aantal kespen teruggeeft."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Mock data heeft 7 kespen (K1 t/m K7)
+    assert onderbouw.totaal_aantal_kespen == 7
+
+
+def test_totaal_aantal_kespen_geen_kespen(mock_rakdeel: Rakdeel):
+    """Test dat totaal_aantal_kespen 0 is als er geen kespen zijn."""
+    mock_rakdeel.onderbouw.kespen = []
+
+    assert mock_rakdeel.onderbouw.totaal_aantal_kespen == 0
+
+
+def test_aantal_beschadigde_kespen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_beschadigde_kespen kespen met vervorming of aantasting telt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Mock data heeft 5 kespen met is_aangetast=True (K2 t/m K6)
+    assert onderbouw.aantal_beschadigde_kespen == 5
+
+
+def test_aantal_beschadigde_kespen_met_vervorming(mock_rakdeel: Rakdeel):
+    """Test dat aantal_beschadigde_kespen ook vervormde kespen meetelt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet K1 (niet aangetast) op vervormd
+    onderbouw.kespen[0].is_vervormd = True
+
+    # Nu zijn er 6 beschadigde kespen: K1 (vervormd) en K2-K6 (aangetast)
+    assert onderbouw.aantal_beschadigde_kespen == 6
+
+
+def test_aantal_beschadigde_kespen_geen_kespen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_beschadigde_kespen 0 is als er geen kespen zijn."""
+    mock_rakdeel.onderbouw.kespen = []
+
+    assert mock_rakdeel.onderbouw.aantal_beschadigde_kespen == 0
+
+
+def test_aantal_aansluitingen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_aansluitingen palen met status GOED of SLECHT telt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Mock data heeft 4 palen, allemaal met aansluiting_status GOED
+    assert onderbouw.aantal_aansluitingen == 4
+
+
+def test_aantal_aansluitingen_gemengd(mock_rakdeel: Rakdeel):
+    """Test dat aantal_aansluitingen zowel GOED als SLECHT aansluitingen telt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet enkele palen op SLECHT
+    onderbouw.palen[0].aansluiting_status = AansluitingStatus.SLECHT
+    onderbouw.palen[1].aansluiting_status = AansluitingStatus.SLECHT
+
+    # Nog steeds 4 aansluitingen (2 GOED + 2 SLECHT)
+    assert onderbouw.aantal_aansluitingen == 4
+
+
+def test_aantal_aansluitingen_met_niet_meetbaar(mock_rakdeel: Rakdeel):
+    """Test dat aantal_aansluitingen palen met status NIET_MEETBAAR niet meetelt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet enkele palen op NIET_MEETBAAR
+    onderbouw.palen[0].aansluiting_status = AansluitingStatus.NIET_MEETBAAR
+    onderbouw.palen[1].aansluiting_status = AansluitingStatus.NIET_MEETBAAR
+
+    # Alleen 2 aansluitingen (de palen met status GOED)
+    assert onderbouw.aantal_aansluitingen == 2
+
+
+def test_aantal_slechte_aansluitingen(mock_rakdeel: Rakdeel):
+    """Test dat aantal_slechte_aansluitingen alleen palen met status SLECHT telt."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Mock data heeft 4 palen, allemaal met aansluiting_status GOED
+    assert onderbouw.aantal_slechte_aansluitingen == 0
+
+
+def test_aantal_slechte_aansluitingen_enkele_slechte(mock_rakdeel: Rakdeel):
+    """Test dat aantal_slechte_aansluitingen correct telt bij enkele slechte aansluitingen."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet twee palen op SLECHT
+    onderbouw.palen[0].aansluiting_status = AansluitingStatus.SLECHT
+    onderbouw.palen[1].aansluiting_status = AansluitingStatus.SLECHT
+
+    assert onderbouw.aantal_slechte_aansluitingen == 2
+
+
+def test_aantal_slechte_aansluitingen_alle_slecht(mock_rakdeel: Rakdeel):
+    """Test dat aantal_slechte_aansluitingen correct telt als alle aansluitingen slecht zijn."""
+    onderbouw = mock_rakdeel.onderbouw
+
+    # Zet alle palen op SLECHT
+    for paal in onderbouw.palen:
+        paal.aansluiting_status = AansluitingStatus.SLECHT
+
+    assert onderbouw.aantal_slechte_aansluitingen == 4

--- a/tests/test_onderbouw.py
+++ b/tests/test_onderbouw.py
@@ -1,99 +1,89 @@
-from tekstherkenning_ark.models.rakdeel import Rakdeel
+from tekstherkenning_ark.models.onderbouw import Onderbouw
 from tekstherkenning_ark.models.paal import Paal
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat, OnverwachtResultaatType
 from tekstherkenning_ark.enums import AansluitingStatus, SchoorStand, NietBeschikbaar
 
 
-def test_percentage_ongewenste_schoorstand_geen(mock_rakdeel: Rakdeel):
+def test_percentage_ongewenste_schoorstand_geen(mock_onderbouw: Onderbouw):
     """Test dat percentage_ongewenste_schoorstand 0% geeft als geen enkele paal PNA heeft."""
     # Alle mock palen hebben schoor_richting="PNV" (geen ongewenste schoorstand)
-    assert mock_rakdeel.onderbouw.percentage_ongewenste_schoorstand == 0.0
+    assert mock_onderbouw.percentage_ongewenste_schoorstand == 0.0
 
 
-def test_aantal_palen_dwars(mock_rakdeel: Rakdeel):
+def test_aantal_palen_dwars(mock_onderbouw: Onderbouw):
     """Test dat aantal_palen_dwars de hoogste paalrij in de onderbouw teruggeeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
-    assert onderbouw.aantal_palen_dwars == 2
+    assert mock_onderbouw.aantal_palen_dwars == 2
 
 
-def test_aantal_palen_dwars_geen_palen(mock_rakdeel: Rakdeel):
+def test_aantal_palen_dwars_geen_palen(mock_onderbouw: Onderbouw):
     """Test dat aantal_palen_dwars 0 is als er geen palen zijn."""
-    mock_rakdeel.onderbouw.palen = []
+    mock_onderbouw.palen = []
 
-    assert mock_rakdeel.onderbouw.aantal_palen_dwars == 0
+    assert mock_onderbouw.aantal_palen_dwars == 0
 
 
-def test_percentage_ongewenste_schoorstand_een_paal(mock_rakdeel: Rakdeel):
+def test_percentage_ongewenste_schoorstand_een_paal(mock_onderbouw: Onderbouw):
     """Test dat percentage_ongewenste_schoorstand correct berekent als één eerste-rij paal PNA heeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet P1.1 (eerste rij) op ongewenste schoorstand
-    p1_1 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P1.1")
+    p1_1 = next(paal for paal in mock_onderbouw.palen if paal.paal_nummer == "P1.1")
     p1_1.schoor_richting = SchoorStand.NEGATIEF
 
     # 1 van 4 palen = 25.0%
-    assert onderbouw.percentage_ongewenste_schoorstand == 25.0
+    assert mock_onderbouw.percentage_ongewenste_schoorstand == 25.0
 
 
-def test_percentage_ongewenste_schoorstand_alle_eerste_rij(mock_rakdeel: Rakdeel):
+def test_percentage_ongewenste_schoorstand_alle_eerste_rij(mock_onderbouw: Onderbouw):
     """Test dat percentage_ongewenste_schoorstand correct berekent als alle eerste-rij palen PNA hebben."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet alle eerste-rij palen (P1.1, P1.2, P1.3) op ongewenste schoorstand
-    for paal in onderbouw.palen:
+    for paal in mock_onderbouw.palen:
         if paal.paalrij_nummer == 1:
             paal.schoor_richting = SchoorStand.NEGATIEF
 
     # 3 van 4 palen = 75.0%
-    assert onderbouw.percentage_ongewenste_schoorstand == 75.0
+    assert mock_onderbouw.percentage_ongewenste_schoorstand == 75.0
 
 
-def test_percentage_ongewenste_schoorstand_tweede_rij_telt_niet_mee(mock_rakdeel: Rakdeel):
+def test_percentage_ongewenste_schoorstand_tweede_rij_telt_niet_mee(mock_onderbouw: Onderbouw):
     """Test dat palen buiten de eerste rij niet meetellen bij ongewenste schoorstand."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet alleen P2.2 (tweede rij) op ongewenste schoorstand
-    p2_2 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P2.2")
+    p2_2 = next(paal for paal in mock_onderbouw.palen if paal.paal_nummer == "P2.2")
     p2_2.schoor_richting = SchoorStand.NEGATIEF
 
     # Tweede-rij palen tellen niet mee → 0%
-    assert onderbouw.percentage_ongewenste_schoorstand == 0.0
+    assert mock_onderbouw.percentage_ongewenste_schoorstand == 0.0
 
 
-def test_percentage_ongewenste_schoorstand_geen_palen(mock_rakdeel: Rakdeel):
+def test_percentage_ongewenste_schoorstand_geen_palen(mock_onderbouw: Onderbouw):
     """Test dat percentage_ongewenste_schoorstand None geeft als er geen palen zijn."""
-    mock_rakdeel.onderbouw.palen = []
+    mock_onderbouw.palen = []
 
-    assert mock_rakdeel.onderbouw.percentage_ongewenste_schoorstand is None
+    assert mock_onderbouw.percentage_ongewenste_schoorstand is None
 
 
-def test_get_eerste_paal_met_aansluitende_statussen_vindt_vijfde_paal(mock_rakdeel: Rakdeel, maak_paal_rij_1):
+def test_get_eerste_paal_met_aansluitende_statussen_vindt_vijfde_paal(mock_onderbouw: Onderbouw, maak_paal_rij_1):
     """Test dat de helper de paal retourneert waarop de aaneengesloten reeks van vijf wordt bereikt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     extra_palen = [
         maak_paal_rij_1("P1.4", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.5", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.6", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.7", AansluitingStatus.SLECHT),
     ]
-    onderbouw.palen.extend(extra_palen)
+    mock_onderbouw.palen.extend(extra_palen)
 
     for paal_nummer in ["P1.1", "P1.2", "P1.3"]:
-        leading_paal = next(p for p in onderbouw.palen if p.paal_nummer == paal_nummer)
+        leading_paal = next(p for p in mock_onderbouw.palen if p.paal_nummer == paal_nummer)
         leading_paal.aansluiting_status = AansluitingStatus.SLECHT
 
-    resultaat = onderbouw.get_eerste_paal_met_aansluitende_statussen((AansluitingStatus.SLECHT,))
+    resultaat = mock_onderbouw.get_eerste_paal_met_aansluitende_statussen((AansluitingStatus.SLECHT,))
 
     assert isinstance(resultaat, Paal)
     assert resultaat.paal_nummer == "P1.5"
 
 
-def test_get_eerste_paal_met_aansluitende_statussen_none_bij_onderbroken_reeks(mock_rakdeel: Rakdeel, maak_paal_rij_1):
+def test_get_eerste_paal_met_aansluitende_statussen_none_bij_onderbroken_reeks(
+    mock_onderbouw: Onderbouw, maak_paal_rij_1
+):
     """Test dat de helper None teruggeeft als er geen vijf aaneengesloten matchende statussen zijn."""
-    onderbouw = mock_rakdeel.onderbouw
-
     extra_palen = [
         maak_paal_rij_1("P1.4", AansluitingStatus.GOED),
         maak_paal_rij_1("P1.5", AansluitingStatus.SLECHT),
@@ -101,28 +91,28 @@ def test_get_eerste_paal_met_aansluitende_statussen_none_bij_onderbroken_reeks(m
         maak_paal_rij_1("P1.7", AansluitingStatus.GOED),
         maak_paal_rij_1("P1.8", AansluitingStatus.SLECHT),
     ]
-    onderbouw.palen.extend(extra_palen)
+    mock_onderbouw.palen.extend(extra_palen)
 
     for paal_nummer in ["P1.1", "P1.2", "P1.3"]:
-        leading_paal = next(p for p in onderbouw.palen if p.paal_nummer == paal_nummer)
+        leading_paal = next(p for p in mock_onderbouw.palen if p.paal_nummer == paal_nummer)
         leading_paal.aansluiting_status = AansluitingStatus.SLECHT
 
-    resultaat = onderbouw.get_eerste_paal_met_aansluitende_statussen((AansluitingStatus.SLECHT,))
+    resultaat = mock_onderbouw.get_eerste_paal_met_aansluitende_statussen((AansluitingStatus.SLECHT,))
 
     assert resultaat is None
 
 
-def test_get_eerste_paal_met_aansluitende_statussen_met_onverwacht_resultaat(mock_rakdeel: Rakdeel, maak_paal_rij_1):
+def test_get_eerste_paal_met_aansluitende_statussen_met_onverwacht_resultaat(
+    mock_onderbouw: Onderbouw, maak_paal_rij_1
+):
     """Test dat OnverwachtResultaat meetelt als include_onverwacht_resultaat=True."""
-    onderbouw = mock_rakdeel.onderbouw
-
     onverwacht = OnverwachtResultaat(
         waarde=None,
         onverwacht_resultaat_type=OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT,
         details="Test onverwacht resultaat",
     )
 
-    onderbouw.palen = [
+    mock_onderbouw.palen = [
         maak_paal_rij_1("P1.1", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.2", AansluitingStatus.NIET_MEETBAAR),
         maak_paal_rij_1("P1.3", AansluitingStatus.SLECHT),
@@ -130,7 +120,7 @@ def test_get_eerste_paal_met_aansluitende_statussen_met_onverwacht_resultaat(moc
         maak_paal_rij_1("P1.5", AansluitingStatus.SLECHT),
     ]
 
-    resultaat = onderbouw.get_eerste_paal_met_aansluitende_statussen(
+    resultaat = mock_onderbouw.get_eerste_paal_met_aansluitende_statussen(
         [AansluitingStatus.SLECHT, AansluitingStatus.NIET_MEETBAAR],
         include_onverwacht_resultaat=True,
     )
@@ -139,34 +129,30 @@ def test_get_eerste_paal_met_aansluitende_statussen_met_onverwacht_resultaat(moc
     assert resultaat.paal_nummer == "P1.5"
 
 
-def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_true(mock_rakdeel: Rakdeel, maak_paal_rij_1):
+def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_true(mock_onderbouw: Onderbouw, maak_paal_rij_1):
     """Test dat de property True is bij vijf aaneengesloten slechte aansluitingen."""
-    onderbouw = mock_rakdeel.onderbouw
-
-    onderbouw.palen = [
+    mock_onderbouw.palen = [
         maak_paal_rij_1("P1.1", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.2", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.3", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.4", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.5", AansluitingStatus.SLECHT),
     ]
-    assert onderbouw.is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij
+    assert mock_onderbouw.is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij
 
 
 def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_onverwacht_resultaat(
-    mock_rakdeel: Rakdeel,
+    mock_onderbouw: Onderbouw,
     maak_paal_rij_1,
 ):
     """Test dat de property een OnverwachtResultaat teruggeeft bij reeks met NM/OnverwachtResultaat."""
-    onderbouw = mock_rakdeel.onderbouw
-
     onverwacht = OnverwachtResultaat(
         waarde=None,
         onverwacht_resultaat_type=OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT,
         details="Test onverwacht resultaat",
     )
 
-    onderbouw.palen = [
+    mock_onderbouw.palen = [
         maak_paal_rij_1("P1.1", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.2", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.3", AansluitingStatus.NIET_MEETBAAR),
@@ -174,7 +160,7 @@ def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_onverwacht_res
         maak_paal_rij_1("P1.5", AansluitingStatus.SLECHT),
     ]
 
-    resultaat = onderbouw.is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij
+    resultaat = mock_onderbouw.is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij
 
     assert isinstance(resultaat, OnverwachtResultaat)
     assert resultaat.waarde is True
@@ -182,13 +168,11 @@ def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_onverwacht_res
 
 
 def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_false_bij_niet_aaneengesloten(
-    mock_rakdeel: Rakdeel,
+    mock_onderbouw: Onderbouw,
     maak_paal_rij_1,
 ):
     """Test dat de property False is bij vijf slechte verbindingen die niet aaneengesloten zijn."""
-    onderbouw = mock_rakdeel.onderbouw
-
-    onderbouw.palen = [
+    mock_onderbouw.palen = [
         maak_paal_rij_1("P1.1", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.2", AansluitingStatus.SLECHT),
         maak_paal_rij_1("P1.3", AansluitingStatus.GOED),
@@ -197,55 +181,46 @@ def test_is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij_false_bij_niet
         maak_paal_rij_1("P1.6", AansluitingStatus.SLECHT),
     ]
 
-    assert onderbouw.is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij is False
+    assert mock_onderbouw.is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij is False
 
 
-def test_aantal_schoorpalen(mock_rakdeel: Rakdeel):
+def test_aantal_schoorpalen(mock_onderbouw: Onderbouw):
     """Test dat aantal_schoorpalen alleen PNV/PNA meetelt."""
-    onderbouw = mock_rakdeel.onderbouw
+    mock_onderbouw.palen[0].schoor_richting = SchoorStand.POSITIEF
+    mock_onderbouw.palen[1].schoor_richting = SchoorStand.NEGATIEF
+    mock_onderbouw.palen[2].schoor_richting = SchoorStand.NEUTRAAL
+    mock_onderbouw.palen[3].schoor_richting = NietBeschikbaar.NIET_VAN_TOEPASSING
 
-    onderbouw.palen[0].schoor_richting = SchoorStand.POSITIEF
-    onderbouw.palen[1].schoor_richting = SchoorStand.NEGATIEF
-    onderbouw.palen[2].schoor_richting = SchoorStand.NEUTRAAL
-    onderbouw.palen[3].schoor_richting = NietBeschikbaar.NIET_VAN_TOEPASSING
-
-    assert onderbouw.aantal_schoorpalen == 2
+    assert mock_onderbouw.aantal_schoorpalen == 2
 
 
-def test_is_schoorpalen_in_een_richting_true(mock_rakdeel: Rakdeel):
+def test_is_schoorpalen_in_een_richting_true(mock_onderbouw: Onderbouw):
     """Test dat is_schoorpalen_in_een_richting True is als alle schoorpalen dezelfde richting hebben."""
-    onderbouw = mock_rakdeel.onderbouw
-
-    for paal in onderbouw.palen:
+    for paal in mock_onderbouw.palen:
         paal.schoor_richting = SchoorStand.POSITIEF
 
-    assert onderbouw.is_schoorpalen_in_een_richting
+    assert mock_onderbouw.is_schoorpalen_in_een_richting
 
 
-def test_is_schoorpalen_in_een_richting_false(mock_rakdeel: Rakdeel):
+def test_is_schoorpalen_in_een_richting_false(mock_onderbouw: Onderbouw):
     """Test dat is_schoorpalen_in_een_richting False is bij gemengde PNV/PNA richtingen."""
-    onderbouw = mock_rakdeel.onderbouw
+    mock_onderbouw.palen[0].schoor_richting = SchoorStand.POSITIEF
+    mock_onderbouw.palen[1].schoor_richting = SchoorStand.NEGATIEF
 
-    onderbouw.palen[0].schoor_richting = SchoorStand.POSITIEF
-    onderbouw.palen[1].schoor_richting = SchoorStand.NEGATIEF
-
-    assert not onderbouw.is_schoorpalen_in_een_richting
+    assert not mock_onderbouw.is_schoorpalen_in_een_richting
 
 
-def test_is_schoorpalen_in_een_richting_niet_van_toepassing(mock_rakdeel: Rakdeel):
+def test_is_schoorpalen_in_een_richting_niet_van_toepassing(mock_onderbouw: Onderbouw):
     """Test dat is_schoorpalen_in_een_richting NVT teruggeeft als er geen schoorpalen zijn."""
-    onderbouw = mock_rakdeel.onderbouw
-
-    for paal in onderbouw.palen:
+    for paal in mock_onderbouw.palen:
         paal.schoor_richting = SchoorStand.NEUTRAAL
 
-    assert onderbouw.is_schoorpalen_in_een_richting is NietBeschikbaar.NIET_VAN_TOEPASSING
+    assert mock_onderbouw.is_schoorpalen_in_een_richting is NietBeschikbaar.NIET_VAN_TOEPASSING
 
 
-def test_eerste_rij_palen(mock_rakdeel: Rakdeel):
+def test_eerste_rij_palen(mock_onderbouw: Onderbouw):
     """Test dat de eerste rij palen correct wordt geïdentificeerd en gesorteerd."""
-
-    eerste_rij_palen = mock_rakdeel.onderbouw.eerste_rij_palen
+    eerste_rij_palen = mock_onderbouw.eerste_rij_palen
 
     assert len(eerste_rij_palen) == 3
     assert eerste_rij_palen[0].paal_nummer == "P1.1"
@@ -253,18 +228,17 @@ def test_eerste_rij_palen(mock_rakdeel: Rakdeel):
     assert eerste_rij_palen[2].paal_nummer == "P1.3"
 
 
-def test_eerste_rij_palen_wrong_order(mock_rakdeel: Rakdeel):
+def test_eerste_rij_palen_wrong_order(mock_onderbouw: Onderbouw):
     """Test dat de eerste rij palen correct wordt geïdentificeerd en gesorteerd."""
-
     # Change the order of palen
-    mock_rakdeel.onderbouw.palen = [
-        mock_rakdeel.onderbouw.palen[1],
-        mock_rakdeel.onderbouw.palen[0],
-        mock_rakdeel.onderbouw.palen[3],
-        mock_rakdeel.onderbouw.palen[2],
+    mock_onderbouw.palen = [
+        mock_onderbouw.palen[1],
+        mock_onderbouw.palen[0],
+        mock_onderbouw.palen[3],
+        mock_onderbouw.palen[2],
     ]
 
-    eerste_rij_palen = mock_rakdeel.onderbouw.eerste_rij_palen
+    eerste_rij_palen = mock_onderbouw.eerste_rij_palen
 
     assert len(eerste_rij_palen) == 3
     assert eerste_rij_palen[0].paal_nummer == "P1.1"
@@ -272,52 +246,45 @@ def test_eerste_rij_palen_wrong_order(mock_rakdeel: Rakdeel):
     assert eerste_rij_palen[2].paal_nummer == "P1.3"
 
 
-def test_eerste_rij_palen_missing(mock_rakdeel: Rakdeel):
+def test_eerste_rij_palen_missing(mock_onderbouw: Onderbouw):
     """Test dat de eerste rij palen correct wordt geïdentificeerd en gesorteerd, ook als er een paal ontbreekt."""
-
     # Remove one of the palen from the first rij
-    mock_rakdeel.onderbouw.palen = [paal for paal in mock_rakdeel.onderbouw.palen if paal.paal_nummer != "P1.2"]
+    mock_onderbouw.palen = [paal for paal in mock_onderbouw.palen if paal.paal_nummer != "P1.2"]
 
-    eerste_rij_palen = mock_rakdeel.onderbouw.eerste_rij_palen
+    eerste_rij_palen = mock_onderbouw.eerste_rij_palen
 
     assert len(eerste_rij_palen) == 2
     assert eerste_rij_palen[0].paal_nummer == "P1.1"
     assert eerste_rij_palen[1].paal_nummer == "P1.3"
 
 
-def test_get_next_paal_normal_case(mock_rakdeel: Rakdeel):
+def test_get_next_paal_normal_case(mock_onderbouw: Onderbouw):
     """Test dat get_next_paal de volgende paal in de reeks correct teruggeeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Test P1.1 -> P1.2
-    p1_1 = onderbouw.palen[0]  # P1.1
-    next_paal = onderbouw.get_next_paal(p1_1)
+    p1_1 = mock_onderbouw.palen[0]  # P1.1
+    next_paal = mock_onderbouw.get_next_paal(p1_1)
 
     assert isinstance(next_paal, Paal)
     assert next_paal.paal_nummer == "P1.2"
 
     # Test P1.2 -> P1.3 (volgens mock data verwijst P1.3 naar P1.2)
-    next_paal = onderbouw.get_next_paal(next_paal)
+    next_paal = mock_onderbouw.get_next_paal(next_paal)
 
     assert isinstance(next_paal, Paal)
     assert next_paal.paal_nummer == "P1.3"
 
 
-def test_get_next_paal_no_next_paal(mock_rakdeel: Rakdeel):
+def test_get_next_paal_no_next_paal(mock_onderbouw: Onderbouw):
     """Test dat get_next_paal None teruggeeft als er geen volgende paal is."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # P1.3 heeft geen volgende paal in de mock data
-    p1_3 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P1.3")
-    next_paal = onderbouw.get_next_paal(p1_3)
+    p1_3 = next(paal for paal in mock_onderbouw.palen if paal.paal_nummer == "P1.3")
+    next_paal = mock_onderbouw.get_next_paal(p1_3)
 
     assert next_paal is None
 
 
-def test_get_next_paal_multiple_references_error(mock_rakdeel: Rakdeel):
+def test_get_next_paal_multiple_references_error(mock_onderbouw: Onderbouw):
     """Test dat get_next_paal een OnverwachtResultaat teruggeeft bij meerdere verwijzingen naar dezelfde paal."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Creëer een nieuwe paal die ook verwijst naar P1.2 (naast P1.3 die al naar P1.2 verwijst in mock data)
     duplicate_paal = Paal(
         paal_nummer="P1.4",
@@ -335,24 +302,22 @@ def test_get_next_paal_multiple_references_error(mock_rakdeel: Rakdeel):
         aansluiting_status=AansluitingStatus.GOED,
         positionering_aansluiting_cm="0",
     )
-    onderbouw.palen.append(duplicate_paal)
+    mock_onderbouw.palen.append(duplicate_paal)
 
-    p1_2 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P1.2")
-    result = onderbouw.get_next_paal(p1_2)
+    p1_2 = next(paal for paal in mock_onderbouw.palen if paal.paal_nummer == "P1.2")
+    result = mock_onderbouw.get_next_paal(p1_2)
 
     assert isinstance(result, OnverwachtResultaat)
     assert result.onverwacht_resultaat_type == OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT
     assert "Meerdere palen verwijzen naar hetzelfde hoh_paalnummer" in result.details
 
 
-def test_get_consecutive_palen_normal_case(mock_rakdeel: Rakdeel):
+def test_get_consecutive_palen_normal_case(mock_onderbouw: Onderbouw):
     """Test dat get_consecutive_palen de palen in de juiste volgorde teruggeeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
-    result = onderbouw.get_consecutive_palen()
+    result = mock_onderbouw.get_consecutive_palen()
 
     assert isinstance(result, list)
-    assert len(result) == len(onderbouw.eerste_rij_palen)
+    assert len(result) == len(mock_onderbouw.eerste_rij_palen)
 
     # Controleer de volgorde: P1.1 -> P1.2 -> P1.3
     assert result[0].paal_nummer == "P1.1"
@@ -360,37 +325,31 @@ def test_get_consecutive_palen_normal_case(mock_rakdeel: Rakdeel):
     assert result[2].paal_nummer == "P1.3"
 
 
-def test_get_consecutive_palen_empty_eerste_rij(mock_rakdeel: Rakdeel):
+def test_get_consecutive_palen_empty_eerste_rij(mock_onderbouw: Onderbouw):
     """Test dat get_consecutive_palen een lege lijst teruggeeft als er geen eerste rij palen zijn."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Verwijder alle eerste rij palen
-    onderbouw.palen = [paal for paal in onderbouw.palen if paal.paalrij_nummer != 1]
+    mock_onderbouw.palen = [paal for paal in mock_onderbouw.palen if paal.paalrij_nummer != 1]
 
-    result = onderbouw.get_consecutive_palen()
+    result = mock_onderbouw.get_consecutive_palen()
 
     assert isinstance(result, list)
     assert len(result) == 0
 
 
-def test_get_consecutive_palen_cyclical_reference_error(mock_rakdeel: Rakdeel):
+def test_get_consecutive_palen_cyclical_reference_error(mock_onderbouw: Onderbouw):
     """Test dat get_consecutive_palen een OnverwachtResultaat teruggeeft bij cyclische verwijzingen."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Create a circular reference by setting hoh_paalnummer to create a loop
-    mock_rakdeel.onderbouw.palen[0].hoh_paalnummer = "P1.3"
+    mock_onderbouw.palen[0].hoh_paalnummer = "P1.3"
 
-    result = onderbouw.get_consecutive_palen()
+    result = mock_onderbouw.get_consecutive_palen()
 
     assert isinstance(result, OnverwachtResultaat)
     assert result.onverwacht_resultaat_type == OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT
     assert "Cyclische paalreferenties gedetecteerd" in result.details
 
 
-def test_get_consecutive_palen_incomplete_chain_error(mock_rakdeel: Rakdeel):
+def test_get_consecutive_palen_incomplete_chain_error(mock_onderbouw: Onderbouw):
     """Test dat get_consecutive_palen een OnverwachtResultaat teruggeeft bij onvolledige verwerking."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Voeg een extra eerste rij paal toe die niet in de keten zit
     extra_paal = Paal(
         paal_nummer="P1.4",
@@ -408,19 +367,17 @@ def test_get_consecutive_palen_incomplete_chain_error(mock_rakdeel: Rakdeel):
         aansluiting_status=AansluitingStatus.GOED,
         positionering_aansluiting_cm="0",
     )
-    onderbouw.palen.append(extra_paal)
+    mock_onderbouw.palen.append(extra_paal)
 
-    result = onderbouw.get_consecutive_palen()
+    result = mock_onderbouw.get_consecutive_palen()
 
     assert isinstance(result, OnverwachtResultaat)
     assert result.onverwacht_resultaat_type == OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT
     assert "Onvolledige verwerking van palen" in result.details
 
 
-def test_get_consecutive_palen_propagates_get_next_paal_error(mock_rakdeel: Rakdeel):
+def test_get_consecutive_palen_propagates_get_next_paal_error(mock_onderbouw: Onderbouw):
     """Test dat get_consecutive_palen errors van get_next_paal correct doorgeeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Creëer situatie waarbij get_next_paal een error geeft (meerdere verwijzingen)
     duplicate_paal = Paal(
         paal_nummer="P1.4",
@@ -438,67 +395,57 @@ def test_get_consecutive_palen_propagates_get_next_paal_error(mock_rakdeel: Rakd
         aansluiting_status=AansluitingStatus.GOED,
         positionering_aansluiting_cm="0",
     )
-    onderbouw.palen.append(duplicate_paal)
+    mock_onderbouw.palen.append(duplicate_paal)
 
-    result = onderbouw.get_consecutive_palen()
+    result = mock_onderbouw.get_consecutive_palen()
 
     assert isinstance(result, OnverwachtResultaat)
     assert result.onverwacht_resultaat_type == OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT
     assert "Meerdere palen verwijzen naar hetzelfde hoh_paalnummer" in result.details
 
 
-def test_get_consecutive_palen_no_hoh_afstand_cm(mock_rakdeel: Rakdeel):
+def test_get_consecutive_palen_no_hoh_afstand_cm(mock_onderbouw: Onderbouw):
     """Test dat get_consecutive_palen een OnverwachtResultaat teruggeeft als een paal geen hoh_afstand_cm heeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Verwijder hoh_afstand_cm van een paal
-    onderbouw.palen[1].hoh_afstand_cm = None
+    mock_onderbouw.palen[1].hoh_afstand_cm = None
 
-    result = onderbouw.get_consecutive_palen()
+    result = mock_onderbouw.get_consecutive_palen()
 
     assert isinstance(result, OnverwachtResultaat)
     assert result.onverwacht_resultaat_type == OnverwachtResultaatType.ONDERLIGGENDE_DATA_INCORRECT
     assert "Ontbrekende hoh_afstand_cm voor paal" in result.details
 
 
-def test_aantal_paalrijen(mock_rakdeel: Rakdeel):
+def test_aantal_paalrijen(mock_onderbouw: Onderbouw):
     """Test dat aantal_paalrijen het aantal unieke paalrijen teruggeeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Mock data heeft palen in rij 1 (P1.1, P1.2, P1.3) en rij 2 (P2.2)
-    assert onderbouw.aantal_paalrijen == 2
+    assert mock_onderbouw.aantal_paalrijen == 2
 
 
-def test_aantal_paalrijen_geen_palen(mock_rakdeel: Rakdeel):
+def test_aantal_paalrijen_geen_palen(mock_onderbouw: Onderbouw):
     """Test dat aantal_paalrijen 0 is als er geen palen zijn."""
-    mock_rakdeel.onderbouw.palen = []
+    mock_onderbouw.palen = []
 
-    assert mock_rakdeel.onderbouw.aantal_paalrijen == 0
+    assert mock_onderbouw.aantal_paalrijen == 0
 
 
-def test_aantal_palen_per_rij(mock_rakdeel: Rakdeel):
+def test_aantal_palen_per_rij(mock_onderbouw: Onderbouw):
     """Test dat aantal_palen_per_rij een correct overzicht geeft van palen per rij."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Mock data heeft 3 palen in rij 1 en 1 paal in rij 2
-    assert onderbouw.aantal_palen_per_rij == {1: 3, 2: 1}
+    assert mock_onderbouw.aantal_palen_per_rij == {1: 3, 2: 1}
 
 
-def test_aantal_palen_per_rij_extra_paal(mock_rakdeel: Rakdeel, maak_paal_rij_1):
+def test_aantal_palen_per_rij_extra_paal(mock_onderbouw: Onderbouw, maak_paal_rij_1):
     """Test dat aantal_palen_per_rij correct update bij het toevoegen van palen."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Voeg extra paal toe aan rij 1
     extra_paal = maak_paal_rij_1("P1.4", AansluitingStatus.GOED)
-    onderbouw.palen.append(extra_paal)
+    mock_onderbouw.palen.append(extra_paal)
 
-    assert onderbouw.aantal_palen_per_rij == {1: 4, 2: 1}
+    assert mock_onderbouw.aantal_palen_per_rij == {1: 4, 2: 1}
 
 
-def test_aantal_palen_per_rij_meerdere_rijen(mock_rakdeel: Rakdeel):
+def test_aantal_palen_per_rij_meerdere_rijen(mock_onderbouw: Onderbouw):
     """Test dat aantal_palen_per_rij correct werkt met meerdere paalrijen."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Voeg palen toe aan een derde rij
     paal_rij_3_1 = Paal(
         paal_nummer="P3.1",
@@ -534,152 +481,126 @@ def test_aantal_palen_per_rij_meerdere_rijen(mock_rakdeel: Rakdeel):
         aansluiting_status=AansluitingStatus.GOED,
         positionering_aansluiting_cm="0",
     )
-    onderbouw.palen.extend([paal_rij_3_1, paal_rij_3_2])
+    mock_onderbouw.palen.extend([paal_rij_3_1, paal_rij_3_2])
 
-    assert onderbouw.aantal_palen_per_rij == {1: 3, 2: 1, 3: 2}
+    assert mock_onderbouw.aantal_palen_per_rij == {1: 3, 2: 1, 3: 2}
 
 
-def test_aantal_ongewenst_schoor(mock_rakdeel: Rakdeel):
+def test_aantal_ongewenst_schoor(mock_onderbouw: Onderbouw):
     """Test dat aantal_ongewenst_schoor alleen eerste-rij palen met negatieve schoorstand telt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Alle palen hebben standaard PNV (positief), dus aantal_ongewenst_schoor moet 0 zijn
-    assert onderbouw.aantal_ongewenst_schoor == 0
+    assert mock_onderbouw.aantal_ongewenst_schoor == 0
 
 
-def test_aantal_ongewenst_schoor_een_paal(mock_rakdeel: Rakdeel):
+def test_aantal_ongewenst_schoor_een_paal(mock_onderbouw: Onderbouw):
     """Test dat aantal_ongewenst_schoor correct telt bij één paal met ongewenste schoorstand."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet P1.1 (eerste rij) op negatieve schoorstand
-    p1_1 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P1.1")
+    p1_1 = next(paal for paal in mock_onderbouw.palen if paal.paal_nummer == "P1.1")
     p1_1.schoor_richting = SchoorStand.NEGATIEF
 
-    assert onderbouw.aantal_ongewenst_schoor == 1
+    assert mock_onderbouw.aantal_ongewenst_schoor == 1
 
 
-def test_aantal_ongewenst_schoor_meerdere_palen(mock_rakdeel: Rakdeel):
+def test_aantal_ongewenst_schoor_meerdere_palen(mock_onderbouw: Onderbouw):
     """Test dat aantal_ongewenst_schoor correct telt bij meerdere palen met ongewenste schoorstand."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet alle eerste-rij palen op negatieve schoorstand
-    for paal in onderbouw.palen:
+    for paal in mock_onderbouw.palen:
         if paal.paalrij_nummer == 1:
             paal.schoor_richting = SchoorStand.NEGATIEF
 
-    assert onderbouw.aantal_ongewenst_schoor == 3
+    assert mock_onderbouw.aantal_ongewenst_schoor == 3
 
 
-def test_aantal_ongewenst_schoor_tweede_rij_telt_niet_mee(mock_rakdeel: Rakdeel):
+def test_aantal_ongewenst_schoor_tweede_rij_telt_niet_mee(mock_onderbouw: Onderbouw):
     """Test dat aantal_ongewenst_schoor alleen eerste-rij palen meetelt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet alleen P2.2 (tweede rij) op negatieve schoorstand
-    p2_2 = next(paal for paal in onderbouw.palen if paal.paal_nummer == "P2.2")
+    p2_2 = next(paal for paal in mock_onderbouw.palen if paal.paal_nummer == "P2.2")
     p2_2.schoor_richting = SchoorStand.NEGATIEF
 
     # Tweede-rij palen meetellen niet
-    assert onderbouw.aantal_ongewenst_schoor == 0
+    assert mock_onderbouw.aantal_ongewenst_schoor == 0
 
 
-def test_totaal_aantal_kespen(mock_rakdeel: Rakdeel):
+def test_totaal_aantal_kespen(mock_onderbouw: Onderbouw):
     """Test dat totaal_aantal_kespen het juiste aantal kespen teruggeeft."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Mock data heeft 7 kespen (K1 t/m K7)
-    assert onderbouw.totaal_aantal_kespen == 7
+    assert mock_onderbouw.totaal_aantal_kespen == 7
 
 
-def test_totaal_aantal_kespen_geen_kespen(mock_rakdeel: Rakdeel):
+def test_totaal_aantal_kespen_geen_kespen(mock_onderbouw: Onderbouw):
     """Test dat totaal_aantal_kespen 0 is als er geen kespen zijn."""
-    mock_rakdeel.onderbouw.kespen = []
+    mock_onderbouw.kespen = []
 
-    assert mock_rakdeel.onderbouw.totaal_aantal_kespen == 0
+    assert mock_onderbouw.totaal_aantal_kespen == 0
 
 
-def test_aantal_beschadigde_kespen(mock_rakdeel: Rakdeel):
+def test_aantal_beschadigde_kespen(mock_onderbouw: Onderbouw):
     """Test dat aantal_beschadigde_kespen kespen met vervorming of aantasting telt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Mock data heeft 5 kespen met is_aangetast=True (K2 t/m K6)
-    assert onderbouw.aantal_beschadigde_kespen == 5
+    assert mock_onderbouw.aantal_beschadigde_kespen == 5
 
 
-def test_aantal_beschadigde_kespen_met_vervorming(mock_rakdeel: Rakdeel):
+def test_aantal_beschadigde_kespen_met_vervorming(mock_onderbouw: Onderbouw):
     """Test dat aantal_beschadigde_kespen ook vervormde kespen meetelt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet K1 (niet aangetast) op vervormd
-    onderbouw.kespen[0].is_vervormd = True
+    mock_onderbouw.kespen[0].is_vervormd = True
 
     # Nu zijn er 6 beschadigde kespen: K1 (vervormd) en K2-K6 (aangetast)
-    assert onderbouw.aantal_beschadigde_kespen == 6
+    assert mock_onderbouw.aantal_beschadigde_kespen == 6
 
 
-def test_aantal_beschadigde_kespen_geen_kespen(mock_rakdeel: Rakdeel):
+def test_aantal_beschadigde_kespen_geen_kespen(mock_onderbouw: Onderbouw):
     """Test dat aantal_beschadigde_kespen 0 is als er geen kespen zijn."""
-    mock_rakdeel.onderbouw.kespen = []
+    mock_onderbouw.kespen = []
 
-    assert mock_rakdeel.onderbouw.aantal_beschadigde_kespen == 0
+    assert mock_onderbouw.aantal_beschadigde_kespen == 0
 
 
-def test_aantal_aansluitingen(mock_rakdeel: Rakdeel):
+def test_aantal_aansluitingen(mock_onderbouw: Onderbouw):
     """Test dat aantal_aansluitingen palen met status GOED of SLECHT telt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Mock data heeft 4 palen, allemaal met aansluiting_status GOED
-    assert onderbouw.aantal_aansluitingen == 4
+    assert mock_onderbouw.aantal_aansluitingen == 4
 
 
-def test_aantal_aansluitingen_gemengd(mock_rakdeel: Rakdeel):
+def test_aantal_aansluitingen_gemengd(mock_onderbouw: Onderbouw):
     """Test dat aantal_aansluitingen zowel GOED als SLECHT aansluitingen telt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet enkele palen op SLECHT
-    onderbouw.palen[0].aansluiting_status = AansluitingStatus.SLECHT
-    onderbouw.palen[1].aansluiting_status = AansluitingStatus.SLECHT
+    mock_onderbouw.palen[0].aansluiting_status = AansluitingStatus.SLECHT
+    mock_onderbouw.palen[1].aansluiting_status = AansluitingStatus.SLECHT
 
     # Nog steeds 4 aansluitingen (2 GOED + 2 SLECHT)
-    assert onderbouw.aantal_aansluitingen == 4
+    assert mock_onderbouw.aantal_aansluitingen == 4
 
 
-def test_aantal_aansluitingen_met_niet_meetbaar(mock_rakdeel: Rakdeel):
+def test_aantal_aansluitingen_met_niet_meetbaar(mock_onderbouw: Onderbouw):
     """Test dat aantal_aansluitingen palen met status NIET_MEETBAAR niet meetelt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet enkele palen op NIET_MEETBAAR
-    onderbouw.palen[0].aansluiting_status = AansluitingStatus.NIET_MEETBAAR
-    onderbouw.palen[1].aansluiting_status = AansluitingStatus.NIET_MEETBAAR
+    mock_onderbouw.palen[0].aansluiting_status = AansluitingStatus.NIET_MEETBAAR
+    mock_onderbouw.palen[1].aansluiting_status = AansluitingStatus.NIET_MEETBAAR
 
     # Alleen 2 aansluitingen (de palen met status GOED)
-    assert onderbouw.aantal_aansluitingen == 2
+    assert mock_onderbouw.aantal_aansluitingen == 2
 
 
-def test_aantal_slechte_aansluitingen(mock_rakdeel: Rakdeel):
+def test_aantal_slechte_aansluitingen(mock_onderbouw: Onderbouw):
     """Test dat aantal_slechte_aansluitingen alleen palen met status SLECHT telt."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Mock data heeft 4 palen, allemaal met aansluiting_status GOED
-    assert onderbouw.aantal_slechte_aansluitingen == 0
+    assert mock_onderbouw.aantal_slechte_aansluitingen == 0
 
 
-def test_aantal_slechte_aansluitingen_enkele_slechte(mock_rakdeel: Rakdeel):
+def test_aantal_slechte_aansluitingen_enkele_slechte(mock_onderbouw: Onderbouw):
     """Test dat aantal_slechte_aansluitingen correct telt bij enkele slechte aansluitingen."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet twee palen op SLECHT
-    onderbouw.palen[0].aansluiting_status = AansluitingStatus.SLECHT
-    onderbouw.palen[1].aansluiting_status = AansluitingStatus.SLECHT
+    mock_onderbouw.palen[0].aansluiting_status = AansluitingStatus.SLECHT
+    mock_onderbouw.palen[1].aansluiting_status = AansluitingStatus.SLECHT
 
-    assert onderbouw.aantal_slechte_aansluitingen == 2
+    assert mock_onderbouw.aantal_slechte_aansluitingen == 2
 
 
-def test_aantal_slechte_aansluitingen_alle_slecht(mock_rakdeel: Rakdeel):
+def test_aantal_slechte_aansluitingen_alle_slecht(mock_onderbouw: Onderbouw):
     """Test dat aantal_slechte_aansluitingen correct telt als alle aansluitingen slecht zijn."""
-    onderbouw = mock_rakdeel.onderbouw
-
     # Zet alle palen op SLECHT
-    for paal in onderbouw.palen:
+    for paal in mock_onderbouw.palen:
         paal.aansluiting_status = AansluitingStatus.SLECHT
 
-    assert onderbouw.aantal_slechte_aansluitingen == 4
+    assert mock_onderbouw.aantal_slechte_aansluitingen == 4

--- a/tests/test_onderbouw.py
+++ b/tests/test_onderbouw.py
@@ -604,3 +604,16 @@ def test_aantal_slechte_aansluitingen_alle_slecht(mock_onderbouw: Onderbouw):
         paal.aansluiting_status = AansluitingStatus.SLECHT
 
     assert mock_onderbouw.aantal_slechte_aansluitingen == 4
+
+
+def test_aantal_rijen_onderzocht_twee_rijen(mock_onderbouw: Onderbouw):
+    """Test dat aantal_rijen_onderzocht het juiste aantal onderzochte paalrijen teruggeeft."""
+    assert mock_onderbouw.aantal_rijen_onderzocht == 2
+
+
+def test_aantal_rijen_onderzocht_een_rij(mock_onderbouw: Onderbouw):
+    """Test dat aantal_rijen_onderzocht het juiste aantal onderzochte paalrijen teruggeeft."""
+    for paal in [p for p in mock_onderbouw.palen if p.paal_nummer_main == 2]:
+        paal.is_onderzocht = False
+
+    assert mock_onderbouw.aantal_rijen_onderzocht == 1


### PR DESCRIPTION
fixes #164 

- Implement new computed fields for json
- Add tests for new fields
- Slightly refactor onderbouw tests, adding `mock_onderbouw` for cleaner code

Mapping ARK: 
- ('onderbouw_fundering', 'aantal_paalrijen') -> `rak.rakdeel.onderbouw.aantal_paalrijen`
- ('onderbouw_fundering', 'palen_per_rij') -> `rak.rakdeel.onderbouw.aantal_palen_per_rij`
- ('onderbouw_fundering', 'aantal_rijen_onderzocht') -> `rak.rakdeel.onderbouw.aantal_rijen_onderzocht`
- ('onderbouw_fundering', 'negatief_schoor') -> `rak.rakdeel.onderbouw.aantal_ongewenst_schoor`
- ('onderbouw_fundering', 'aantal_kespen') -> `rak.rakdeel.onderbouw.totaal_aantal_kespen`
- ('onderbouw_fundering', 'beschadigde_kespen') -> `rak.rakdeel.onderbouw.aantal_beschadigde_kespen`
- ('onderbouw_fundering', 'aantal_aansluitingen') -> `rak.rakdeel.onderbouw.aantal_aansluitingen`
- ('onderbouw_fundering', 'slechte_aansluitingen') -> `rak.rakdeel.onderbouw.aantal_slechte_aansluitingen`