### PR TITLE
include computed fields in alle_onverwacht_resultaten

### DIFF
--- a/src/tekstherkenning_ark/models/rak.py
+++ b/src/tekstherkenning_ark/models/rak.py
@@ -11,11 +11,9 @@ from tekstherkenning_ark import constants
 from tekstherkenning_ark.constants import DATA_DIR
 from tekstherkenning_ark.models.houtmonster import Houtmonster
 from tekstherkenning_ark.models.kesp import Kesp
-from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat
 from tekstherkenning_ark.models.paal import Paal
-from tekstherkenning_ark.models.rak_base_model import RakBaseModel, T_Gebrek
+from tekstherkenning_ark.models.rak_base_model import RakBaseModel
 from tekstherkenning_ark.models.rakdeel import Rakdeel
-from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.document.smart_document import SmartDocument
 from tekstherkenning_ark.logger import get_logger
 from tekstherkenning_ark.export_utils import (
@@ -56,16 +54,6 @@ class Rak(RakBaseModel):
     def identifier(self) -> str:
         """Return a string that uniquely identifies this Rak instance."""
         return str(self.raknaam)
-
-    @computed_field
-    @property
-    def alle_gebreken(self) -> list[tuple[str, T_Gebrek]]:
-        return super().alle_gebreken
-
-    @computed_field
-    @property
-    def alle_onverwachte_resultaten(self) -> list[tuple[str, OnverwachtResultaat]]:
-        return super().alle_onverwachte_resultaten
 
     @computed_field
     @property

--- a/src/tekstherkenning_ark/models/rak_base_model.py
+++ b/src/tekstherkenning_ark/models/rak_base_model.py
@@ -84,7 +84,14 @@ class RakBaseModel(BaseModel):
     def onverwachte_resultaten(self) -> list[OnverwachtResultaat]:
         """Return a list of all OnverwachtResultaat objects in this model"""
 
-        return [value for value in self.__dict__.values() if isinstance(value, OnverwachtResultaat)]
+        values = list(self.__dict__.values())
+        computed_values = [
+            getattr(self, attr)
+            for attr in self.__class__.model_computed_fields
+            if not "onverwachte_resultaten" in attr
+        ]
+
+        return [value for value in values + computed_values if isinstance(value, OnverwachtResultaat)]
 
     @property
     def children(self) -> list[RakBaseModel]:

--- a/src/tekstherkenning_ark/models/rakdeel.py
+++ b/src/tekstherkenning_ark/models/rakdeel.py
@@ -9,7 +9,7 @@ from tekstherkenning_ark.enums import NietBeschikbaar
 from tekstherkenning_ark.models.onderloopsheidscherm import Onderloopsheidscherm
 from tekstherkenning_ark.models.onverwacht_resultaat import OnverwachtResultaat, OnverwachtResultaatType
 from tekstherkenning_ark.models.paal import Paal
-from tekstherkenning_ark.models.rak_base_model import RakBaseModel
+from tekstherkenning_ark.models.rak_base_model import RakBaseModel, T_Gebrek
 from tekstherkenning_ark.models.toestand_onderdeel import ToestandOnderdeel
 from tekstherkenning_ark.models.vloer import Vloer
 from tekstherkenning_ark.document.smart_document import RakdeelSectie
@@ -70,6 +70,16 @@ class Rakdeel(RakBaseModel):
     def identifier(self) -> str:
         """Return a string that uniquely identifies this Rakdeel instance."""
         return str(self.rakdeel_id)
+
+    @computed_field
+    @property
+    def alle_onverwachte_resultaten(self) -> list[tuple[str, OnverwachtResultaat]]:
+        return super().alle_onverwachte_resultaten
+
+    @computed_field
+    @property
+    def alle_gebreken(self) -> list[tuple[str, T_Gebrek]]:
+        return super().alle_gebreken
 
     @computed_field
     @property

--- a/tests/data/mock_rak_with_scheuren.json
+++ b/tests/data/mock_rak_with_scheuren.json
@@ -146,6 +146,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 1,
+            "paal_nummer_main": 1,
             "n_scheuren": 2,
             "is_ongewenste_schoorstand": false
           },
@@ -175,6 +177,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 2,
+            "paal_nummer_main": 1,
             "n_scheuren": 1,
             "is_ongewenste_schoorstand": false
           },
@@ -204,6 +208,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 1,
+            "paal_nummer_main": 2,
             "n_scheuren": 1,
             "is_ongewenste_schoorstand": false
           },
@@ -227,6 +233,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 1,
+            "paal_nummer_main": 3,
             "n_scheuren": 0,
             "is_ongewenste_schoorstand": false
           },
@@ -250,6 +258,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 2,
+            "paal_nummer_main": 3,
             "n_scheuren": 0,
             "is_ongewenste_schoorstand": false
           },
@@ -273,6 +283,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 1,
+            "paal_nummer_main": 4,
             "n_scheuren": 0,
             "is_ongewenste_schoorstand": false
           },
@@ -302,6 +314,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 2,
+            "paal_nummer_main": 4,
             "n_scheuren": 1,
             "is_ongewenste_schoorstand": false
           },
@@ -325,6 +339,8 @@
             "aansluiting_status": "G",
             "positionering_aansluiting_cm": "0",
             "houtmonsters": [],
+            "paalrij_nummer": 1,
+            "paal_nummer_main": 5,
             "n_scheuren": 0,
             "is_ongewenste_schoorstand": false
           }
@@ -341,21 +357,209 @@
         "onderloopsheidscherm": null,
         "materiaal": "",
         "materiaal_fundering": "",
+        "aantal_paalrijen": 2,
+        "aantal_palen_per_rij": {
+          "1": 5,
+          "2": 3
+        },
+        "aantal_rijen_onderzocht": 0,
         "aantal_palen_dwars": 2,
+        "aantal_aansluitingen": 8,
+        "aantal_slechte_aansluitingen": 0,
         "totaal_aantal_palen": 8,
         "is_vijf_aansluitende_slechte_paal_kesp_verbinding_in_rij": false,
         "aantal_onderzochte_palen": 0,
         "percentage_slechte_palen": 0.0,
+        "aantal_ongewenst_schoor": 0,
         "percentage_ongewenste_schoorstand": 0.0,
         "aantal_palen_met_scheefstand": 0,
         "is_schoorpalen_in_een_richting": true,
         "aantal_schoorpalen": 8,
         "aantal_palen_met_paalbreuk": 0,
         "totaal_aantal_kespen": 0,
+        "aantal_beschadigde_kespen": 0,
         "percentage_beschadigde_kespen": null,
         "percentage_vervormde_kespen": null,
         "percentage_beschadigde_verbinding": 0.0
       },
+      "alle_onverwachte_resultaten": [],
+      "alle_gebreken": [
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S1",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 0.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S2",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 2.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S3",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 5.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S4",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 12.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S5",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 18.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S5",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 19.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S5",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 20.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S5",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 21.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S5",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 40.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/bovenbouw",
+          {
+            "codering": "S5",
+            "omschrijving": "Scheur in metselwerk",
+            "figuurnummer": "",
+            "afstand_van_startrak_m": 56.0,
+            "lengte_cm": "",
+            "scheurwijdte_mm": ""
+          }
+        ],
+        [
+          "Constructie A/onderbouw/P1.1",
+          {
+            "codering": "SH1.1.1",
+            "omschrijving": "Scheur in hout verticaal",
+            "figuurnummer": "F1",
+            "afstand_van_startrak_m": "",
+            "lengte_cm": 10.0,
+            "scheurwijdte_mm": 20.0,
+            "diepte_cm": 5.0,
+            "orientatie": "verticaal"
+          }
+        ],
+        [
+          "Constructie A/onderbouw/P1.1",
+          {
+            "codering": "SH1.1.2",
+            "omschrijving": "Scheur in hout horizontaal",
+            "figuurnummer": "F2",
+            "afstand_van_startrak_m": "",
+            "lengte_cm": 8.0,
+            "scheurwijdte_mm": 15.0,
+            "diepte_cm": 3.0,
+            "orientatie": "horizontaal"
+          }
+        ],
+        [
+          "Constructie A/onderbouw/P2.1",
+          {
+            "codering": "SH2.1.1",
+            "omschrijving": "Scheur in hout horizontaal",
+            "figuurnummer": "F4",
+            "afstand_van_startrak_m": "",
+            "lengte_cm": 6.0,
+            "scheurwijdte_mm": 10.0,
+            "diepte_cm": 4.0,
+            "orientatie": "horizontaal"
+          }
+        ],
+        [
+          "Constructie A/onderbouw/P1.2",
+          {
+            "codering": "SH1.2.1",
+            "omschrijving": "Scheur in hout verticaal",
+            "figuurnummer": "F5",
+            "afstand_van_startrak_m": "",
+            "lengte_cm": 12.0,
+            "scheurwijdte_mm": 25.0,
+            "diepte_cm": 8.0,
+            "orientatie": "verticaal"
+          }
+        ],
+        [
+          "Constructie A/onderbouw/P2.4",
+          {
+            "codering": "SH2.4.1",
+            "omschrijving": "Scheur in hout verticaal",
+            "figuurnummer": "F11",
+            "afstand_van_startrak_m": "",
+            "lengte_cm": 20.0,
+            "scheurwijdte_mm": 50.0,
+            "diepte_cm": 15.0,
+            "orientatie": "verticaal"
+          }
+        ]
+      ],
       "percentage_niet_functionerend_schuifhout": null,
       "vijf_slechte_kespen_naast_elkaar": false,
       "maximaal_aantal_scheuren_per_10_m": 5,
@@ -368,183 +572,5 @@
   "unassigned_palen": [],
   "unassigned_kespen": [],
   "unassigned_houtmonsters": [],
-  "alle_gebreken": [
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S1",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 0.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S2",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 2.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S3",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 5.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S4",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 12.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S5",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 18.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S5",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 19.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S5",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 20.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S5",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 21.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S5",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 40.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/bovenbouw",
-      {
-        "codering": "S5",
-        "omschrijving": "Scheur in metselwerk",
-        "figuurnummer": "",
-        "afstand_van_startrak_m": 56.0,
-        "lengte_cm": "",
-        "scheurwijdte_mm": ""
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/onderbouw/P1.1",
-      {
-        "codering": "SH1.1.1",
-        "omschrijving": "Scheur in hout verticaal",
-        "figuurnummer": "F1",
-        "afstand_van_startrak_m": "",
-        "lengte_cm": 10.0,
-        "scheurwijdte_mm": 20.0,
-        "diepte_cm": 5.0,
-        "orientatie": "verticaal"
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/onderbouw/P1.1",
-      {
-        "codering": "SH1.1.2",
-        "omschrijving": "Scheur in hout horizontaal",
-        "figuurnummer": "F2",
-        "afstand_van_startrak_m": "",
-        "lengte_cm": 8.0,
-        "scheurwijdte_mm": 15.0,
-        "diepte_cm": 3.0,
-        "orientatie": "horizontaal"
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/onderbouw/P2.1",
-      {
-        "codering": "SH2.1.1",
-        "omschrijving": "Scheur in hout horizontaal",
-        "figuurnummer": "F4",
-        "afstand_van_startrak_m": "",
-        "lengte_cm": 6.0,
-        "scheurwijdte_mm": 10.0,
-        "diepte_cm": 4.0,
-        "orientatie": "horizontaal"
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/onderbouw/P1.2",
-      {
-        "codering": "SH1.2.1",
-        "omschrijving": "Scheur in hout verticaal",
-        "figuurnummer": "F5",
-        "afstand_van_startrak_m": "",
-        "lengte_cm": 12.0,
-        "scheurwijdte_mm": 25.0,
-        "diepte_cm": 8.0,
-        "orientatie": "verticaal"
-      }
-    ],
-    [
-      "Test Rak Maximaal Scheuren/Constructie A/onderbouw/P2.4",
-      {
-        "codering": "SH2.4.1",
-        "omschrijving": "Scheur in hout verticaal",
-        "figuurnummer": "F11",
-        "afstand_van_startrak_m": "",
-        "lengte_cm": 20.0,
-        "scheurwijdte_mm": 50.0,
-        "diepte_cm": 15.0,
-        "orientatie": "verticaal"
-      }
-    ]
-  ],
-  "alle_onverwachte_resultaten": [],
   "aantal_rakdelen": 1
 }

--- a/tests/test_rak.py
+++ b/tests/test_rak.py
@@ -22,6 +22,7 @@ import pytest
 
 from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.models.rak import Rak
+from tests.conftest import TEST_DATA_DIR
 
 
 def test_kzg0202(kzg0202_rak: Rak):
@@ -32,7 +33,7 @@ def test_kzg0202(kzg0202_rak: Rak):
 
 def test_kzg0202_nul_onverwacht(kzg0202_rak: Rak):
     """Test that the Rak instance from the test cache has the expected gebreken."""
-    aantal_overwacht_tot = len(kzg0202_rak.alle_onverwachte_resultaten)
+    aantal_overwacht_tot = len(kzg0202_rak.rakdelen[0].alle_onverwachte_resultaten)
     assert aantal_overwacht_tot == 0, f"Expected 0 onverwachte resultaten, got {aantal_overwacht_tot}"
 
 
@@ -82,6 +83,10 @@ class TestRakToJson:
         """Test that a mock Rak with scheuren can be serialized to JSON."""
         json_str = mock_rak_with_scheuren.model_dump_json(indent=2)
 
+        # Uncomment this line to update the expected JSON file with the current output
+        # (useful when intentionally changing the model structure or test data)
+        # (TEST_DATA_DIR / "mock_rak_with_scheuren.json").write_text(json_str, encoding="utf-8")
+
         expected_dict = json.loads(mock_rak_with_scheuren_json)
         actual_dict = json.loads(json_str)
 
@@ -90,7 +95,7 @@ class TestRakToJson:
             == expected_dict["rakdelen"][0]["bovenbouw"]["gebreken"]
         ), "Gebreken in bovenbouw komen niet overeen"
 
-        assert actual_dict["alle_gebreken"] == expected_dict["alle_gebreken"]
+        assert actual_dict["rakdelen"][0]["alle_gebreken"] == expected_dict["rakdelen"][0]["alle_gebreken"]
 
     @pytest.mark.parametrize("gebrek_class", [Gebrek] + Gebrek.__subclasses__())
     def test_gebrek_subclasses_to_json(self, gebrek_class: type[Gebrek]):

--- a/tests/test_rak.py
+++ b/tests/test_rak.py
@@ -22,7 +22,6 @@ import pytest
 
 from tekstherkenning_ark.models.gebrek import Gebrek
 from tekstherkenning_ark.models.rak import Rak
-from tests.conftest import TEST_DATA_DIR
 
 
 def test_kzg0202(kzg0202_rak: Rak):
@@ -83,8 +82,10 @@ class TestRakToJson:
         """Test that a mock Rak with scheuren can be serialized to JSON."""
         json_str = mock_rak_with_scheuren.model_dump_json(indent=2)
 
-        # Uncomment this line to update the expected JSON file with the current output
+        # Uncomment these line to update the expected JSON file with the current output
         # (useful when intentionally changing the model structure or test data)
+
+        # from tests.conftest import TEST_DATA_DIR
         # (TEST_DATA_DIR / "mock_rak_with_scheuren.json").write_text(json_str, encoding="utf-8")
 
         expected_dict = json.loads(mock_rak_with_scheuren_json)


### PR DESCRIPTION
fixes #171 

Nieuwe json: 
[HEG0201_260311_0959.json](https://github.com/user-attachments/files/25896272/HEG0201_260311_0959.json)

Voegt `computed_field` OnverwachteResultaten toe aan `alle_onverwachte_resultaten`, en zet dit veld en `alle_gebreken` in `Rakdeel` ipv `Rak`